### PR TITLE
Add note to README on using np for mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ a prebuilt one](https://github.com/Nanopublication/nanopub-java/releases):
 
     $ java -jar nanopub-1.21-jar-with-dependencies.jar check nanopubfile.trig
 
+Note: For Mac users, before running `np` ensure that the GNU versions of `curl` and `sed` are installed (not the default BSD versions), and are the ones being used when '`curl`' or '`sed`' commands are invoked.
 
 Developers
 ----------


### PR DESCRIPTION
Macs have annoying system versions of sed etc that differ from the GNU versions. The jar download step in np fails with cryptic error messages if the standard mac sed is used. A package manager (e.g. homebrew) needs to be used to install the proper versions. This adds a note to the README to warn mac users about this.