### PR TITLE
Add Dockerfile to run np command through Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM openjdk:8-jre
+# FROM maven:3-jdk-8
+
+WORKDIR /app
+
+## The Dockerfile download the latest jar release
+# It could also be used to build the jar file
+
+## Re-download dependencies only if change to pom.xml
+# COPY ./pom.xml ./pom.xml
+# RUN mvn dependency:go-offline -B
+
+COPY ./src ./src
+COPY ./bin ./bin
+COPY ./scripts ./scripts
+
+## Build  jar
+# RUN mvn clean install
+# RUN cp target/*.jar ??
+
+# Put np in the $PATH
+RUN cp bin/np /bin/np
+
+# Download the jar using np a first time
+RUN np help
+
+ENTRYPOINT [ "np" ]
+CMD [ "help" ]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,28 @@ a prebuilt one](https://github.com/Nanopublication/nanopub-java/releases):
 
 Note: For Mac users, before running `np` ensure that the GNU versions of `curl` and `sed` are installed (not the default BSD versions), and are the ones being used when '`curl`' or '`sed`' commands are invoked.
 
+## Docker
+
+Using [image from DockerHub](https://hub.docker.com/repository/docker/umids/nanopub-java).
+
+Sign a nanopublication (`nanopub.trig` file in current dir here):
+
+```bash
+docker run -it --rm -v ~/.nanopub:/root/.nanopub -v $(pwd):/data umids/nanopub-java sign /data/nanopub.trig
+```
+
+Publish a signed nanopublication:
+
+```bash
+docker run -it --rm -v ~/.nanopub:/root/.nanopub -v $(pwd):/data umids/nanopub-java publish /data/signed.nanopub.trig
+```
+
+Build the Docker image:
+
+```shell
+docker build -t umids/nanopub-java .
+```
+
 Developers
 ----------
 


### PR DESCRIPTION
* Add Dockerfile to run np command through Docker
* Added documentation to sign and publish with local id_rsa key (tested with the one generated by my local nanobench) to the README

At the moment the `Dockerfile` automatically download the jar using `np help` a first time. I added some commands commented to build the jar in the Dockerfile (feel free to remove them if you prefer keeping the auto download)

Thanks for this tool