### PR TITLE
NanopubStream counter metadata integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>eu.ostrzyciel.jelly</groupId>
       <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.7.0</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/src/main/java/org/nanopub/jelly/JellyMetadataUtil.java
+++ b/src/main/java/org/nanopub/jelly/JellyMetadataUtil.java
@@ -1,0 +1,58 @@
+package org.nanopub.jelly;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import scala.Some$;
+import scala.Tuple2;
+import scala.collection.immutable.Map;
+
+import java.io.IOException;
+
+/**
+ * Utilities for working with metadata of Jelly RdfStreamFrames.
+ * This is used for example to serve the counter metadata in the Registry.
+ */
+public class JellyMetadataUtil {
+    public static final String COUNTER_KEY = "c";
+
+    /**
+     * Create a metadata map with the counter key.
+     * The counter is encoded as a Protobuf varint.
+     * @param counter The counter value to store
+     * @return A map with the counter key and the counter value
+     */
+    public static Map<String, ByteString> getCounterMetadata(long counter) {
+        int size = CodedOutputStream.computeUInt64SizeNoTag(counter);
+        byte[] bytes = new byte[size];
+        CodedOutputStream codedOutputStream = CodedOutputStream.newInstance(bytes);
+        try {
+            codedOutputStream.writeInt64NoTag(counter);
+        } catch (IOException e) {
+            // Should not happen, really
+            throw new RuntimeException(e);
+        }
+        return Map.from(Some$.MODULE$.apply(
+            Tuple2.apply(COUNTER_KEY, ByteString.copyFrom(bytes))
+        ));
+    }
+
+    /**
+     * Try to get the counter value from the metadata.
+     * If the counter is not present or cannot be read, -1 is returned.
+     * @param metadata The metadata map to read from
+     * @return The counter value, or -1 if it cannot be read
+     */
+    public static long tryGetCounterFromMetadata(Map<String, ByteString> metadata) {
+        var maybeCounterBytes = metadata.get(COUNTER_KEY);
+        if (maybeCounterBytes.isEmpty()) {
+            return -1;
+        }
+        var is = CodedInputStream.newInstance(maybeCounterBytes.get().asReadOnlyByteBuffer());
+        try {
+            return is.readInt64();
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/org/nanopub/jelly/JellyUtils.java
+++ b/src/main/java/org/nanopub/jelly/JellyUtils.java
@@ -24,7 +24,6 @@ import java.util.stream.Stream;
 
 /**
  * Utility functions for working with Jelly RDF data.
- * TODO: consider putting this in the nanopub-java library?
  */
 public class JellyUtils {
 
@@ -65,10 +64,9 @@ public class JellyUtils {
     /**
      * Read a Nanopub from bytes in the Jelly format stored in the database.
      * <p>
-     * This is only needed because nanopub-java does not support parsing binary data as input.
-     * Nonetheless, this should be a bit faster than going through RDF4J Rio, because we are
-     * dealing with a special (simpler) case here.
-     * TODO: fix this in nanopub-java?
+     * This specialized implementation should be a bit faster than going through RDF4J Rio,
+     * because we are dealing with a special (simpler) case here.
+     *
      * @param jellyBytes Jelly RDF bytes (non-delimited)
      * @return Nanopub
      * @throws MalformedNanopubException if this is not a valid Nanopub
@@ -80,9 +78,7 @@ public class JellyUtils {
 
     /**
      * Read one Nanopub from an input byte stream in the Jelly format. This can be used on HTTP responses.
-     * <p>
-     * This is only needed because nanopub-java does not support parsing binary data as input.
-     * TODO: fix this in nanopub-java?
+     *
      * @param is Jelly RDF data (delimited, one frame (!!!))
      * @return Nanopub
      * @throws MalformedNanopubException if this is not a valid Nanopub
@@ -111,7 +107,11 @@ public class JellyUtils {
                 statements.clear();
                 namespaces.clear();
                 parseStatements(frame, decoder, statements);
-                return new MaybeNanopub(new NanopubImpl(statements, namespaces));
+                return new MaybeNanopub(
+                        new NanopubImpl(statements, namespaces),
+                        // Extract the counter metadata from the frame
+                        JellyMetadataUtil.tryGetCounterFromMetadata(frame.metadata())
+                );
             } catch (MalformedNanopubException e) {
                 return new MaybeNanopub(e);
             }

--- a/src/main/java/org/nanopub/jelly/JellyWriterRDFHandler.java
+++ b/src/main/java/org/nanopub/jelly/JellyWriterRDFHandler.java
@@ -1,5 +1,6 @@
 package org.nanopub.jelly;
 
+import com.google.protobuf.ByteString;
 import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
 import eu.ostrzyciel.jelly.core.ProtoEncoder;
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame;
@@ -10,6 +11,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import scala.Some$;
+import scala.collection.immutable.Map;
 import scala.collection.mutable.ListBuffer;
 
 /**
@@ -38,12 +40,25 @@ public class JellyWriterRDFHandler extends AbstractRDFHandler {
 
     /**
      * Call this at the end of a nanopub.
-     * This flushes the buffer and returns the RdfStreamFrame corresponding to one nanopub.
      * @return RdfStreamFrame
      */
     public RdfStreamFrame getFrame() {
+        return getFrame(-1);
+    }
+
+    /**
+     * Call this at the end of a nanopub.
+     * This flushes the buffer and returns the RdfStreamFrame corresponding to one nanopub.
+     * @param counter The counter value to store in the frame metadata. If < 0, no metadata is added.
+     * @return RdfStreamFrame
+     */
+    public RdfStreamFrame getFrame(long counter) {
         var rows = rowBuffer.toList();
         rowBuffer.clear();
-        return RdfStreamFrame$.MODULE$.apply(rows);
+        scala.collection.immutable.Map<String, ByteString> metadata = null;
+        if (counter >= 0) {
+            metadata = JellyMetadataUtil.getCounterMetadata(counter);
+        }
+        return RdfStreamFrame$.MODULE$.apply(rows, metadata);
     }
 }

--- a/src/main/java/org/nanopub/jelly/MaybeNanopub.java
+++ b/src/main/java/org/nanopub/jelly/MaybeNanopub.java
@@ -11,17 +11,27 @@ public class MaybeNanopub {
     private final boolean success;
     private final Nanopub nanopub;
     private final Exception exception;
+    private final long counter;
 
     public MaybeNanopub(Exception ex) {
         success = false;
         nanopub = null;
         exception = ex;
+        counter = -1;
     }
 
     public MaybeNanopub(Nanopub np) {
         success = true;
         nanopub = np;
         exception = null;
+        counter = -1;
+    }
+
+    public MaybeNanopub(Nanopub np, long counter) {
+        success = true;
+        nanopub = np;
+        exception = null;
+        this.counter = counter;
     }
 
     public boolean isSuccess() {
@@ -34,6 +44,16 @@ public class MaybeNanopub {
 
     public Nanopub getNanopub() {
         return nanopub;
+    }
+
+    /**
+     * Counter may be attached to Jelly responses from the Registry.
+     * It can be used to track the progress of a stream of Nanopubs.
+     * Will return a negative value if the counter is not present.
+     * @return counter
+     */
+    public long getCounter() {
+        return counter;
     }
 
     public Exception getException() {

--- a/src/test/java/org/nanopub/jelly/JellyMetadataUtilTest.java
+++ b/src/test/java/org/nanopub/jelly/JellyMetadataUtilTest.java
@@ -1,0 +1,43 @@
+package org.nanopub.jelly;
+
+import com.google.protobuf.ByteString;
+import org.junit.Test;
+import scala.Some$;
+import scala.Tuple2;
+import scala.collection.immutable.Map;
+import scala.collection.immutable.Map$;
+
+public class JellyMetadataUtilTest {
+
+    private final long[] testCases = {0, 1, 200, Integer.MAX_VALUE, Long.MAX_VALUE};
+
+    @Test
+    public void testCounterMetadataRoundTrip() {
+        assert JellyMetadataUtil.COUNTER_KEY == "c";
+
+        for (long testCase : testCases) {
+            var m = JellyMetadataUtil.getCounterMetadata(testCase);
+            assert m.contains(JellyMetadataUtil.COUNTER_KEY);
+            assert m.size() == 1;
+            // Parsing
+            var counter = JellyMetadataUtil.tryGetCounterFromMetadata(m);
+            assert counter == testCase;
+        }
+    }
+
+    @Test
+    public void testGetCounterNoKey() {
+        var m = (Object) Map$.MODULE$.empty();
+        var counter = JellyMetadataUtil.tryGetCounterFromMetadata((Map<String, ByteString>) m);
+        assert counter == -1;
+    }
+
+    @Test
+    public void testGetCounterEmptyArray() {
+        var m = Map.from(Some$.MODULE$.apply(
+                Tuple2.apply(JellyMetadataUtil.COUNTER_KEY, ByteString.copyFrom(new byte[0]))
+        ));
+        var counter = JellyMetadataUtil.tryGetCounterFromMetadata(m);
+        assert counter == -1;
+    }
+}


### PR DESCRIPTION
This adds support for embedding a metadata field in Jelly streams that indicates the `counter` integer value.  Basically, each `RdfStreamFrame` (so, each nanopub) is paired with one metadata value.

This is encoded as a Protobuf varint, under metadata key `c`, using the newly-added feature in Jelly 1.1.1: https://github.com/Jelly-RDF/jelly-protobuf/issues/32

I've done a test integration of this with the Registry and it worked.

Note that this counter metadata is not intended to be stored in the database, together with the rest of the Jelly data. Storing it there would reduce the overhead on reads (but only by a small amount), but it would complicate writes and make all responses longer, no matter if they need the counter or not.