### PR TITLE
Hopefully fix syntax highlighting errors with Scala Map

### DIFF
--- a/src/main/java/org/nanopub/jelly/JellyMetadataUtil.java
+++ b/src/main/java/org/nanopub/jelly/JellyMetadataUtil.java
@@ -5,7 +5,6 @@ import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 import scala.Some$;
 import scala.Tuple2;
-import scala.collection.immutable.Map;
 import scala.collection.immutable.Map$;
 
 import java.io.IOException;
@@ -16,7 +15,7 @@ import java.io.IOException;
  */
 public class JellyMetadataUtil {
     public static final String COUNTER_KEY = "c";
-    public static final Map<String, ByteString> EMPTY_METADATA = Map$.MODULE$.empty();
+    public static final scala.collection.immutable.Map<String, ByteString> EMPTY_METADATA = Map$.MODULE$.empty();
 
     /**
      * Create a metadata map with the counter key.
@@ -24,7 +23,7 @@ public class JellyMetadataUtil {
      * @param counter The counter value to store
      * @return A map with the counter key and the counter value
      */
-    public static Map<String, ByteString> getCounterMetadata(long counter) {
+    public static scala.collection.immutable.Map<String, ByteString> getCounterMetadata(long counter) {
         int size = CodedOutputStream.computeUInt64SizeNoTag(counter);
         byte[] bytes = new byte[size];
         CodedOutputStream codedOutputStream = CodedOutputStream.newInstance(bytes);
@@ -34,7 +33,7 @@ public class JellyMetadataUtil {
             // Should not happen, really
             throw new RuntimeException(e);
         }
-        return Map.from(Some$.MODULE$.apply(
+        return scala.collection.immutable.Map.from(Some$.MODULE$.apply(
             Tuple2.apply(COUNTER_KEY, ByteString.copyFrom(bytes))
         ));
     }
@@ -45,7 +44,7 @@ public class JellyMetadataUtil {
      * @param metadata The metadata map to read from
      * @return The counter value, or -1 if it cannot be read
      */
-    public static long tryGetCounterFromMetadata(Map<String, ByteString> metadata) {
+    public static long tryGetCounterFromMetadata(scala.collection.immutable.Map<String, ByteString> metadata) {
         var maybeCounterBytes = metadata.get(COUNTER_KEY);
         if (maybeCounterBytes.isEmpty()) {
             return -1;

--- a/src/main/java/org/nanopub/jelly/JellyWriterRDFHandler.java
+++ b/src/main/java/org/nanopub/jelly/JellyWriterRDFHandler.java
@@ -1,6 +1,5 @@
 package org.nanopub.jelly;
 
-import com.google.protobuf.ByteString;
 import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
 import eu.ostrzyciel.jelly.core.ProtoEncoder;
 import eu.ostrzyciel.jelly.core.proto.v1.RdfStreamFrame;
@@ -11,7 +10,6 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import scala.Some$;
-import scala.collection.immutable.Map;
 import scala.collection.mutable.ListBuffer;
 
 /**

--- a/src/test/java/org/nanopub/jelly/JellyMetadataUtilTest.java
+++ b/src/test/java/org/nanopub/jelly/JellyMetadataUtilTest.java
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString;
 import org.junit.Test;
 import scala.Some$;
 import scala.Tuple2;
-import scala.collection.immutable.Map;
 import scala.collection.immutable.Map$;
 
 public class JellyMetadataUtilTest {
@@ -28,13 +27,15 @@ public class JellyMetadataUtilTest {
     @Test
     public void testGetCounterNoKey() {
         var m = (Object) Map$.MODULE$.empty();
-        var counter = JellyMetadataUtil.tryGetCounterFromMetadata((Map<String, ByteString>) m);
+        var counter = JellyMetadataUtil.tryGetCounterFromMetadata(
+                (scala.collection.immutable.Map<String, ByteString>) m
+        );
         assert counter == -1;
     }
 
     @Test
     public void testGetCounterEmptyArray() {
-        var m = Map.from(Some$.MODULE$.apply(
+        var m = scala.collection.immutable.Map.from(Some$.MODULE$.apply(
                 Tuple2.apply(JellyMetadataUtil.COUNTER_KEY, ByteString.copyFrom(new byte[0]))
         ));
         var counter = JellyMetadataUtil.tryGetCounterFromMetadata(m);


### PR DESCRIPTION
The errors in some IDEs *might* be caused by an ambiguous type reference. It should not really be ambiguous, but we can make sure it isn't by explicitly specifying the correct type using its FQN.

I haven't found anything else in the `Map`'s bytecode that could confuse the syntax highlighter. It does not override anything, and the type signature for `get` is super-simple.