### PR TITLE
Refactoring of the cli commands

### DIFF
--- a/src/main/java/org/nanopub/CheckNanopub.java
+++ b/src/main/java/org/nanopub/CheckNanopub.java
@@ -1,12 +1,7 @@
 package org.nanopub;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.security.GeneralSecurityException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriUtils;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -19,12 +14,14 @@ import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
 import org.nanopub.trusty.TrustyNanopubUtils;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.List;
 
-import net.trustyuri.TrustyUriUtils;
-
-public class CheckNanopub {
+public class CheckNanopub extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<String> inputNanopubs = new ArrayList<String>();
@@ -36,19 +33,13 @@ public class CheckNanopub {
 	private String sparqlEndpointUrl;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		CheckNanopub obj = new CheckNanopub();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			CheckNanopub obj = Run.initJc(new CheckNanopub(), args);
 			obj.setLogPrintStream(System.out);
 			Report report = obj.check();
 			System.out.println("Summary: " + report.getSummary());
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -60,17 +51,20 @@ public class CheckNanopub {
 	private SPARQLRepository sparqlRepo;
 	private PrintStream logOut;
 
+	public CheckNanopub() {}
+
+	/**
+	 * This constructor does not initialize the CliRunner as usual. It's for testing purposes.
+	 */
 	public CheckNanopub(List<String> inputNanopubFiles) {
 		this.inputNanopubs = inputNanopubFiles;
 	}
 
-	public CheckNanopub(String...  inputNanopubFiles) {
-		for (String i : inputNanopubFiles) {
-			this.inputNanopubs.add(i);
-		}
-	}
-
+	/**
+	 * This constructor does not initialize the CliRunner as usual. It's for testing purposes.
+	 */
 	public CheckNanopub(String sparqlEndpointUrl, List<String> inputNanopubIds) {
+		super();
 		this.inputNanopubs = inputNanopubIds;
 		this.sparqlEndpointUrl = sparqlEndpointUrl;
 	}

--- a/src/main/java/org/nanopub/CheckNanopub.java
+++ b/src/main/java/org/nanopub/CheckNanopub.java
@@ -34,7 +34,7 @@ public class CheckNanopub extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			CheckNanopub obj = Run.initJc(new CheckNanopub(), args);
+			CheckNanopub obj = CliRunner.initJc(new CheckNanopub(), args);
 			obj.setLogPrintStream(System.out);
 			Report report = obj.check();
 			System.out.println("Summary: " + report.getSummary());

--- a/src/main/java/org/nanopub/CliRunner.java
+++ b/src/main/java/org/nanopub/CliRunner.java
@@ -1,0 +1,21 @@
+package org.nanopub;
+
+import com.beust.jcommander.JCommander;
+
+/**
+ * Base class for all cli commands.
+ */
+public abstract class CliRunner {
+
+    /** the initialized JCommander */
+    private JCommander jc;
+
+    public JCommander getJc() {
+        return jc;
+    }
+
+    public void setJc(JCommander jc) {
+        this.jc = jc;
+    }
+
+}

--- a/src/main/java/org/nanopub/CliRunner.java
+++ b/src/main/java/org/nanopub/CliRunner.java
@@ -1,6 +1,7 @@
 package org.nanopub;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 
 /**
  * Base class for all cli commands.
@@ -10,11 +11,23 @@ public abstract class CliRunner {
     /** the initialized JCommander */
     private JCommander jc;
 
+    public static <T extends CliRunner> T initJc(T obj, String[] args) {
+        JCommander jc = new JCommander(obj);
+        ((CliRunner) obj).setJc(jc);
+        try {
+            jc.parse(args);
+        } catch (ParameterException ex) {
+            jc.usage();
+            throw ex;
+        }
+        return obj;
+    }
+
     public JCommander getJc() {
         return jc;
     }
 
-    public void setJc(JCommander jc) {
+    private void setJc(JCommander jc) {
         this.jc = jc;
     }
 

--- a/src/main/java/org/nanopub/Nanopub2Html.java
+++ b/src/main/java/org/nanopub/Nanopub2Html.java
@@ -1,26 +1,19 @@
 package org.nanopub;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
+import com.beust.jcommander.ParameterException;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 
-public class Nanopub2Html {
+public class Nanopub2Html extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<String> inputNanopubs = new ArrayList<String>();
@@ -39,25 +32,18 @@ public class Nanopub2Html {
 	private static final Charset utf8Charset = Charset.forName("UTF8");
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Nanopub2Html obj = new Nanopub2Html();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Nanopub2Html obj = Run.initJc(new Nanopub2Html(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
 		}
 	}
 
-	private Nanopub2Html() {
-	}
+	public Nanopub2Html() {}
 
 	private Nanopub2Html(OutputStream outputStream, boolean standalone, boolean indentContext) {
 		this.outputStream = outputStream;

--- a/src/main/java/org/nanopub/Nanopub2Html.java
+++ b/src/main/java/org/nanopub/Nanopub2Html.java
@@ -33,7 +33,7 @@ public class Nanopub2Html extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Nanopub2Html obj = Run.initJc(new Nanopub2Html(), args);
+			Nanopub2Html obj = CliRunner.initJc(new Nanopub2Html(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/NanopubImpl.java
+++ b/src/main/java/org/nanopub/NanopubImpl.java
@@ -95,6 +95,9 @@ public class NanopubImpl implements NanopubWithNs, Serializable {
 		};
 	}
 
+	/**
+	 * Just ensures the class to be loaded. Probably unnecessary.
+	 */
 	public static void ensureLoaded() {
 		// ensure class is loaded; nothing left to be done
 	}

--- a/src/main/java/org/nanopub/Run.java
+++ b/src/main/java/org/nanopub/Run.java
@@ -1,12 +1,7 @@
 package org.nanopub;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.nanopub.extra.index.MakeIndex;
 import org.nanopub.extra.security.MakeKeys;
@@ -19,6 +14,9 @@ import org.nanopub.extra.services.RunQuery;
 import org.nanopub.extra.setting.ShowSetting;
 import org.nanopub.trusty.FixTrustyNanopub;
 import org.nanopub.trusty.MakeTrustyNanopub;
+
+import java.io.IOException;
+import java.util.*;
 
 public class Run {
 
@@ -62,6 +60,18 @@ public class Run {
 		addRunnableClass(org.nanopub.op.Run.class, "op");
 		addRunnableClass(ShowSetting.class, "setting");
 		addRunnableClass(RunQuery.class, "query");
+	}
+
+	public static <T extends CliRunner> T initJc(T obj, String[] args) {
+		JCommander jc = new JCommander(obj);
+		obj.setJc(jc);
+		try {
+			jc.parse(args);
+		} catch (ParameterException ex) {
+			jc.usage();
+			throw ex;
+		}
+		return obj;
 	}
 
 	public static void run(String[] command) throws IOException, RDF4JException {

--- a/src/main/java/org/nanopub/Run.java
+++ b/src/main/java/org/nanopub/Run.java
@@ -1,7 +1,5 @@
 package org.nanopub;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.nanopub.extra.index.MakeIndex;
 import org.nanopub.extra.security.MakeKeys;
@@ -60,18 +58,6 @@ public class Run {
 		addRunnableClass(org.nanopub.op.Run.class, "op");
 		addRunnableClass(ShowSetting.class, "setting");
 		addRunnableClass(RunQuery.class, "query");
-	}
-
-	public static <T extends CliRunner> T initJc(T obj, String[] args) {
-		JCommander jc = new JCommander(obj);
-		obj.setJc(jc);
-		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			throw ex;
-		}
-		return obj;
 	}
 
 	public static void run(String[] command) throws IOException, RDF4JException {

--- a/src/main/java/org/nanopub/TimestampNow.java
+++ b/src/main/java/org/nanopub/TimestampNow.java
@@ -1,35 +1,23 @@
 package org.nanopub;
 
-import java.util.Date;
-
+import com.beust.jcommander.ParameterException;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.util.Date;
 
-
-public class TimestampNow {
+public class TimestampNow extends CliRunner {
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		TimestampNow obj = new TimestampNow();
-		JCommander jc = new JCommander(obj);
-		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
+		TimestampNow obj = Run.initJc(new TimestampNow(), args);
 		try {
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
 		}
-	}
-
-	private TimestampNow() {
 	}
 
 	private void run() {

--- a/src/main/java/org/nanopub/TimestampNow.java
+++ b/src/main/java/org/nanopub/TimestampNow.java
@@ -9,7 +9,7 @@ import java.util.Date;
 public class TimestampNow extends CliRunner {
 
 	public static void main(String[] args) {
-		TimestampNow obj = Run.initJc(new TimestampNow(), args);
+		TimestampNow obj = CliRunner.initJc(new TimestampNow(), args);
 		try {
 			obj.run();
 		} catch (ParameterException ex) {

--- a/src/main/java/org/nanopub/extra/index/MakeIndex.java
+++ b/src/main/java/org/nanopub/extra/index/MakeIndex.java
@@ -68,7 +68,7 @@ public class MakeIndex extends CliRunner {
 
 	public static void main(String[] args) throws IOException {
 		try {
-			MakeIndex obj = Run.initJc(new MakeIndex(), args);
+			MakeIndex obj = CliRunner.initJc(new MakeIndex(), args);
 			if (obj.inputFiles.isEmpty() && obj.elements.isEmpty() && obj.subindexes.isEmpty() && obj.supersededIndex == null) {
 				obj.getJc().usage();
 			}

--- a/src/main/java/org/nanopub/extra/index/MakeIndex.java
+++ b/src/main/java/org/nanopub/extra/index/MakeIndex.java
@@ -1,30 +1,19 @@
 package org.nanopub.extra.index;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
+import com.beust.jcommander.ParameterException;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+import org.nanopub.*;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+
+import java.io.*;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-public class MakeIndex {
+public class MakeIndex extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopub-files")
 	private List<File> inputFiles = new ArrayList<File>();
@@ -78,21 +67,14 @@ public class MakeIndex {
 //	private SignatureAlgorithm algorithm;
 
 	public static void main(String[] args) throws IOException {
-		NanopubImpl.ensureLoaded();
-		MakeIndex obj = new MakeIndex();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		if (obj.inputFiles.isEmpty() && obj.elements.isEmpty() && obj.subindexes.isEmpty() && obj.supersededIndex == null) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			MakeIndex obj = Run.initJc(new MakeIndex(), args);
+			if (obj.inputFiles.isEmpty() && obj.elements.isEmpty() && obj.subindexes.isEmpty() && obj.supersededIndex == null) {
+				obj.getJc().usage();
+			}
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -104,9 +86,6 @@ public class MakeIndex {
 	private RDFFormat outFormat;
 	private int count;
 //	private KeyPair key;
-
-	private MakeIndex() {
-	}
 
 	private void init() throws IOException {
 		count = 0;

--- a/src/main/java/org/nanopub/extra/security/MakeKeys.java
+++ b/src/main/java/org/nanopub/extra/security/MakeKeys.java
@@ -1,5 +1,10 @@
 package org.nanopub.extra.security;
 
+import com.beust.jcommander.ParameterException;
+import org.nanopub.CliRunner;
+import org.nanopub.Run;
+
+import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -9,14 +14,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 
-import javax.xml.bind.DatatypeConverter;
-
-import org.nanopub.NanopubImpl;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-public class MakeKeys {
+public class MakeKeys extends CliRunner {
 
 	@com.beust.jcommander.Parameter(names = "-f", description = "Path and file name prefix of key files")
 	private String pathAndFilenamePrefix = "~/.nanopub/id";
@@ -26,7 +24,7 @@ public class MakeKeys {
 
 	public static void main(String[] args) throws IOException {
 		try {
-			MakeKeys obj = init(args);
+			MakeKeys obj = Run.initJc(new MakeKeys(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);
@@ -34,22 +32,6 @@ public class MakeKeys {
 			ex.printStackTrace();
 			System.exit(1);
 		}
-	}
-
-	static MakeKeys init(String[] args) {
-		NanopubImpl.ensureLoaded();
-		MakeKeys obj = new MakeKeys();
-		JCommander jc = new JCommander(obj);
-		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			throw ex;
-		}
-		return obj;
-	}
-
-	private MakeKeys() {
 	}
 
 	private void run() throws IOException {

--- a/src/main/java/org/nanopub/extra/security/MakeKeys.java
+++ b/src/main/java/org/nanopub/extra/security/MakeKeys.java
@@ -2,7 +2,6 @@ package org.nanopub.extra.security;
 
 import com.beust.jcommander.ParameterException;
 import org.nanopub.CliRunner;
-import org.nanopub.Run;
 
 import javax.xml.bind.DatatypeConverter;
 import java.io.File;
@@ -24,7 +23,7 @@ public class MakeKeys extends CliRunner {
 
 	public static void main(String[] args) throws IOException {
 		try {
-			MakeKeys obj = Run.initJc(new MakeKeys(), args);
+			MakeKeys obj = CliRunner.initJc(new MakeKeys(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/security/SignNanopub.java
+++ b/src/main/java/org/nanopub/extra/security/SignNanopub.java
@@ -48,7 +48,7 @@ public class SignNanopub extends CliRunner {
 
 	public static void main(String[] args) throws IOException {
 		try {
-			SignNanopub obj = Run.initJc(new SignNanopub(), args);
+			SignNanopub obj = CliRunner.initJc(new SignNanopub(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/security/SignNanopub.java
+++ b/src/main/java/org/nanopub/extra/security/SignNanopub.java
@@ -1,20 +1,17 @@
 package org.nanopub.extra.security;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import net.trustyuri.TrustyUriResource;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.rdf4j.rio.*;
+import org.nanopub.*;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.*;
 import java.nio.charset.Charset;
-import java.security.InvalidKeyException;
-import java.security.KeyFactory;
-import java.security.KeyPair;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.SignatureException;
+import java.security.*;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -23,29 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
-import javax.xml.bind.DatatypeConverter;
-
-import org.apache.commons.io.IOUtils;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
-import org.nanopub.NanopubWithNs;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriException;
-import net.trustyuri.TrustyUriResource;
-
-public class SignNanopub {
+public class SignNanopub extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopub-files", required = true)
 	private List<File> inputNanopubFiles = new ArrayList<File>();
@@ -73,7 +48,7 @@ public class SignNanopub {
 
 	public static void main(String[] args) throws IOException {
 		try {
-			SignNanopub obj = init(args);
+			SignNanopub obj = Run.initJc(new SignNanopub(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);
@@ -83,25 +58,12 @@ public class SignNanopub {
 		}
 	}
 
-	static SignNanopub init(String[] args) throws ParameterException {
-		NanopubImpl.ensureLoaded();
-		SignNanopub obj = new SignNanopub();
-		JCommander jc = new JCommander(obj);
-		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			throw ex;
-		}
-		return obj;
-	}
-
 	private KeyPair key;
 
-	private SignNanopub() {
-	}
+	public SignNanopub() {
+    }
 
-	void run() throws Exception {
+	protected void run() throws Exception {
 		if (algorithm == null) {
 			if (keyFilename == null) {
 				keyFilename = "~/.nanopub/id_rsa";

--- a/src/main/java/org/nanopub/extra/server/GetNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/GetNanopub.java
@@ -69,7 +69,7 @@ public class GetNanopub extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			GetNanopub obj = Run.initJc(new GetNanopub(), args);
+			GetNanopub obj = CliRunner.initJc(new GetNanopub(), args);
 			simulateUnreliableConnection = obj.simUnrelConn;
 			obj.run();
 		} catch (ParameterException ex) {

--- a/src/main/java/org/nanopub/extra/server/GetNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/GetNanopub.java
@@ -1,40 +1,28 @@
 package org.nanopub.extra.server;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.rdf.RdfModule;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.rdf4j.common.exception.RDF4JException;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.nanopub.*;
+import org.nanopub.trusty.TrustyNanopubUtils;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.http.HttpResponse;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.util.EntityUtils;
-import org.eclipse.rdf4j.common.exception.RDF4JException;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
-import org.nanopub.trusty.TrustyNanopubUtils;
+import static org.nanopub.extra.server.NanopubStatus.extractArtifactCode;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriUtils;
-import net.trustyuri.rdf.RdfModule;
-
-public class GetNanopub {
+public class GetNanopub extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "nanopub-uris-or-artifact-codes", required = true)
 	private List<String> nanopubIds;
@@ -80,18 +68,12 @@ public class GetNanopub {
 	private boolean simUnrelConn;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		GetNanopub obj = new GetNanopub();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		simulateUnreliableConnection = obj.simUnrelConn;
-		try {
+			GetNanopub obj = Run.initJc(new GetNanopub(), args);
+			simulateUnreliableConnection = obj.simUnrelConn;
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -182,18 +164,7 @@ public class GetNanopub {
 	}
 
 	public static String getArtifactCode(String uriOrArtifactCode) {
-		if (uriOrArtifactCode.indexOf(":") > 0) {
-			IRI uri = SimpleValueFactory.getInstance().createIRI(uriOrArtifactCode);
-			if (!TrustyUriUtils.isPotentialTrustyUri(uri)) {
-				throw new IllegalArgumentException("Not a well-formed trusty URI");
-			}
-			return TrustyUriUtils.getArtifactCode(uri.toString());
-		} else {
-			if (!TrustyUriUtils.isPotentialArtifactCode(uriOrArtifactCode)) {
-				throw new IllegalArgumentException("Not a well-formed artifact code");
-			}
-			return uriOrArtifactCode;
-		}
+		return extractArtifactCode(uriOrArtifactCode);
 	}
 
 	private OutputStream outputStream = System.out;
@@ -204,10 +175,9 @@ public class GetNanopub {
 
 	private RDFFormat rdfFormat;
 
-	public GetNanopub() {
-	}
+	public GetNanopub() {}
 
-	private void run() throws IOException, RDFHandlerException, MalformedNanopubException {
+	protected void run() throws IOException, RDFHandlerException, MalformedNanopubException {
 		if (showReport) {
 			exceptions = new ArrayList<>();
 		}

--- a/src/main/java/org/nanopub/extra/server/GetServerInfo.java
+++ b/src/main/java/org/nanopub/extra/server/GetServerInfo.java
@@ -2,7 +2,6 @@ package org.nanopub.extra.server;
 
 import com.beust.jcommander.ParameterException;
 import org.nanopub.CliRunner;
-import org.nanopub.Run;
 import org.nanopub.extra.server.ServerInfo.ServerInfoException;
 
 import java.io.IOException;
@@ -15,7 +14,7 @@ public class GetServerInfo extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			GetServerInfo obj = Run.initJc(new GetServerInfo(), args);
+			GetServerInfo obj = CliRunner.initJc(new GetServerInfo(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/server/GetServerInfo.java
+++ b/src/main/java/org/nanopub/extra/server/GetServerInfo.java
@@ -1,31 +1,24 @@
 package org.nanopub.extra.server;
 
+import com.beust.jcommander.ParameterException;
+import org.nanopub.CliRunner;
+import org.nanopub.Run;
+import org.nanopub.extra.server.ServerInfo.ServerInfoException;
+
 import java.io.IOException;
 import java.util.List;
 
-import org.nanopub.NanopubImpl;
-import org.nanopub.extra.server.ServerInfo.ServerInfoException;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-public class GetServerInfo {
+public class GetServerInfo extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "server-urls", required = true)
 	private List<String> serverUrls;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		GetServerInfo obj = new GetServerInfo();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			GetServerInfo obj = Run.initJc(new GetServerInfo(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/server/NanopubStatus.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubStatus.java
@@ -10,7 +10,6 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.nanopub.CliRunner;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
-import org.nanopub.Run;
 import org.nanopub.extra.index.IndexUtils;
 import org.nanopub.extra.index.NanopubIndex;
 
@@ -34,7 +33,7 @@ public class NanopubStatus extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			NanopubStatus obj = Run.initJc(new NanopubStatus(), args);
+			NanopubStatus obj = CliRunner.initJc(new NanopubStatus(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/server/NanopubStatus.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubStatus.java
@@ -1,26 +1,24 @@
 package org.nanopub.extra.server;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.List;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriUtils;
+import net.trustyuri.rdf.RdfModule;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.nanopub.CliRunner;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
+import org.nanopub.Run;
 import org.nanopub.extra.index.IndexUtils;
 import org.nanopub.extra.index.NanopubIndex;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
 
-import net.trustyuri.TrustyUriUtils;
-import net.trustyuri.rdf.RdfModule;
-
-public class NanopubStatus {
+public class NanopubStatus extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "nanopub-uri-or-artifact-code", required = true)
 	private List<String> nanopubIds;
@@ -35,22 +33,11 @@ public class NanopubStatus {
 	private boolean checkAllServers = false;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		NanopubStatus obj = new NanopubStatus();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		if (obj.nanopubIds.size() != 1) {
-			System.err.println("ERROR: Exactly one main argument needed");
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			NanopubStatus obj = Run.initJc(new NanopubStatus(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -58,6 +45,10 @@ public class NanopubStatus {
 	}
 
 	private static String getArtifactCode(String uriOrArtifactCode) {
+		return extractArtifactCode(uriOrArtifactCode);
+	}
+
+	static String extractArtifactCode(String uriOrArtifactCode) {
 		if (uriOrArtifactCode.indexOf(":") > 0) {
 			IRI uri = SimpleValueFactory.getInstance().createIRI(uriOrArtifactCode);
 			if (!TrustyUriUtils.isPotentialTrustyUri(uri)) {

--- a/src/main/java/org/nanopub/extra/server/PublishNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/PublishNanopub.java
@@ -1,12 +1,7 @@
 package org.nanopub.extra.server;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -15,19 +10,17 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import net.trustyuri.TrustyUriUtils;
-
-public class PublishNanopub {
+public class PublishNanopub extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "nanopubs", required = true)
 	private List<String> nanopubs = new ArrayList<String>();
@@ -42,17 +35,11 @@ public class PublishNanopub {
 	private String sparqlEndpointUrl;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		PublishNanopub obj = new PublishNanopub();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			PublishNanopub obj = Run.initJc(new PublishNanopub(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -72,6 +59,7 @@ public class PublishNanopub {
 	private String artifactCode;
 
 	public PublishNanopub() {
+		super();
 	}
 
 	private void run() throws IOException {

--- a/src/main/java/org/nanopub/extra/server/PublishNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/PublishNanopub.java
@@ -36,7 +36,7 @@ public class PublishNanopub extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			PublishNanopub obj = Run.initJc(new PublishNanopub(), args);
+			PublishNanopub obj = CliRunner.initJc(new PublishNanopub(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/services/RunQuery.java
+++ b/src/main/java/org/nanopub/extra/services/RunQuery.java
@@ -3,7 +3,6 @@ package org.nanopub.extra.services;
 import com.beust.jcommander.ParameterException;
 import com.opencsv.exceptions.CsvValidationException;
 import org.nanopub.CliRunner;
-import org.nanopub.Run;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -21,7 +20,7 @@ public class RunQuery extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			RunQuery obj = Run.initJc(new RunQuery(), args);
+			RunQuery obj = CliRunner.initJc(new RunQuery(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/services/RunQuery.java
+++ b/src/main/java/org/nanopub/extra/services/RunQuery.java
@@ -1,16 +1,17 @@
 package org.nanopub.extra.services;
 
+import com.beust.jcommander.ParameterException;
+import com.opencsv.exceptions.CsvValidationException;
+import org.nanopub.CliRunner;
+import org.nanopub.Run;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-import com.opencsv.exceptions.CsvValidationException;
-
-public class RunQuery {
+public class RunQuery extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "query-id", required = true)
 	private String queryId;
@@ -19,16 +20,11 @@ public class RunQuery {
 	private List<String> params;
 
 	public static void main(String[] args) {
-		RunQuery obj = new RunQuery();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			RunQuery obj = Run.initJc(new RunQuery(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/setting/ShowSetting.java
+++ b/src/main/java/org/nanopub/extra/setting/ShowSetting.java
@@ -1,29 +1,22 @@
 package org.nanopub.extra.setting;
 
-import java.io.IOException;
-
+import com.beust.jcommander.ParameterException;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.IRI;
+import org.nanopub.CliRunner;
 import org.nanopub.MalformedNanopubException;
-import org.nanopub.NanopubImpl;
+import org.nanopub.Run;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.IOException;
 
-public class ShowSetting {
+public class ShowSetting extends CliRunner {
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		ShowSetting obj = new ShowSetting();
-		JCommander jc = new JCommander(obj);
-		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
+		ShowSetting obj = Run.initJc(new ShowSetting(), args);
 		try {
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/extra/setting/ShowSetting.java
+++ b/src/main/java/org/nanopub/extra/setting/ShowSetting.java
@@ -5,14 +5,13 @@ import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.model.IRI;
 import org.nanopub.CliRunner;
 import org.nanopub.MalformedNanopubException;
-import org.nanopub.Run;
 
 import java.io.IOException;
 
 public class ShowSetting extends CliRunner {
 
 	public static void main(String[] args) {
-		ShowSetting obj = Run.initJc(new ShowSetting(), args);
+		ShowSetting obj = CliRunner.initJc(new ShowSetting(), args);
 		try {
 			obj.run();
 		} catch (ParameterException ex) {

--- a/src/main/java/org/nanopub/op/Aggregate.java
+++ b/src/main/java/org/nanopub/op/Aggregate.java
@@ -8,9 +8,11 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 
 import java.io.*;
 import java.util.*;
@@ -38,7 +40,7 @@ public class Aggregate extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Aggregate obj = Run.initJc(new Aggregate(), args);
+			Aggregate obj = CliRunner.initJc(new Aggregate(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);
@@ -52,7 +54,7 @@ public class Aggregate extends CliRunner {
 		if (args == null) {
 			args = "";
 		}
-		Aggregate obj = Run.initJc(new Aggregate(), args.trim().split(" "));
+		Aggregate obj = CliRunner.initJc(new Aggregate(), args.trim().split(" "));
 		return obj;
 	}
 

--- a/src/main/java/org/nanopub/op/Aggregate.java
+++ b/src/main/java/org/nanopub/op/Aggregate.java
@@ -1,42 +1,22 @@
 package org.nanopub.op;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.zip.GZIPOutputStream;
-
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.model.ValueFactory;
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.util.*;
+import java.util.zip.GZIPOutputStream;
 
-import net.trustyuri.TrustyUriException;
-
-public class Aggregate {
+public class Aggregate extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs")
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -57,18 +37,11 @@ public class Aggregate {
 	private String inFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Aggregate obj = new Aggregate();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		obj.init();
-		try {
+			Aggregate obj = Run.initJc(new Aggregate(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -76,20 +49,15 @@ public class Aggregate {
 	}
 
 	public static Aggregate getInstance(String args) throws ParameterException {
-		NanopubImpl.ensureLoaded();
-		if (args == null) args = "";
-		Aggregate obj = new Aggregate();
-		JCommander jc = new JCommander(obj);
-		jc.parse(args.trim().split(" "));
-		obj.init();
+		if (args == null) {
+			args = "";
+		}
+		Aggregate obj = Run.initJc(new Aggregate(), args.trim().split(" "));
 		return obj;
 	}
 
 	private RDFFormat rdfInFormat;
 	private Map<Statement,Integer> headCounts, assertionCounts, provCounts, pubinfoCounts;
-
-	private void init() {
-	}
 
 	public void run() throws IOException, RDFParseException, RDFHandlerException,
 			MalformedNanopubException, TrustyUriException {

--- a/src/main/java/org/nanopub/op/Build.java
+++ b/src/main/java/org/nanopub/op/Build.java
@@ -8,7 +8,6 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.*;
-import org.nanopub.Run;
 import org.nanopub.*;
 
 import java.io.*;
@@ -40,7 +39,7 @@ public class Build extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Build obj = Run.initJc(new Build(), args);
+			Build obj = CliRunner.initJc(new Build(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Build.java
+++ b/src/main/java/org/nanopub/op/Build.java
@@ -1,41 +1,24 @@
 package org.nanopub.op;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.*;
+import org.nanopub.Run;
+import org.nanopub.*;
+
+import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandler;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubCreator;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriException;
-
-public class Build {
+public class Build extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-rdf-files", required = true)
 	private List<File> inputRdfdFiles = new ArrayList<File>();
@@ -56,17 +39,11 @@ public class Build {
 	private String outFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Build obj = new Build();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Build obj = Run.initJc(new Build(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Count.java
+++ b/src/main/java/org/nanopub/op/Count.java
@@ -1,5 +1,15 @@
 package org.nanopub.op;
 
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.nanopub.*;
+import org.nanopub.Run;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -7,22 +17,7 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.trustyuri.TrustyUriException;
-
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.Rio;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-public class Count {
+public class Count extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs")
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -34,17 +29,11 @@ public class Count {
 	private String inFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Count obj = new Count();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Count obj = Run.initJc(new Count(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -52,11 +41,10 @@ public class Count {
 	}
 
 	public static Count getInstance(String args) throws ParameterException {
-		NanopubImpl.ensureLoaded();
-		if (args == null) args = "";
-		Count obj = new Count();
-		JCommander jc = new JCommander(obj);
-		jc.parse(args.trim().split(" "));
+		if (args == null) {
+			args = "";
+		}
+		Count obj = Run.initJc(new Count(), args.trim().split(" "));
 		return obj;
 	}
 

--- a/src/main/java/org/nanopub/op/Count.java
+++ b/src/main/java/org/nanopub/op/Count.java
@@ -6,9 +6,11 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -30,7 +32,7 @@ public class Count extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Count obj = Run.initJc(new Count(), args);
+			Count obj = CliRunner.initJc(new Count(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);
@@ -44,7 +46,7 @@ public class Count extends CliRunner {
 		if (args == null) {
 			args = "";
 		}
-		Count obj = Run.initJc(new Count(), args.trim().split(" "));
+		Count obj = CliRunner.initJc(new Count(), args.trim().split(" "));
 		return obj;
 	}
 

--- a/src/main/java/org/nanopub/op/Create.java
+++ b/src/main/java/org/nanopub/op/Create.java
@@ -9,7 +9,6 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.Run;
 import org.nanopub.*;
 
 import java.io.File;
@@ -29,7 +28,7 @@ public class Create extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Create obj = Run.initJc(new Create(), args);
+			Create obj = CliRunner.initJc(new Create(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Create.java
+++ b/src/main/java/org/nanopub/op/Create.java
@@ -1,12 +1,7 @@
 package org.nanopub.op;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Random;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -14,18 +9,17 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubCreator;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
+import org.nanopub.Run;
+import org.nanopub.*;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Random;
+import java.util.zip.GZIPOutputStream;
 
-import net.trustyuri.TrustyUriException;
-
-public class Create {
+public class Create extends CliRunner {
 
 	@com.beust.jcommander.Parameter(names = "-o", description = "Output file")
 	private File outputFile;
@@ -34,17 +28,11 @@ public class Create {
 	private String format;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Create obj = new Create();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Create obj = Run.initJc(new Create(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Decontextualize.java
+++ b/src/main/java/org/nanopub/op/Decontextualize.java
@@ -9,7 +9,6 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.*;
 import org.nanopub.*;
-import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 import org.nanopub.op.fingerprint.FingerprintHandler;
 
@@ -34,7 +33,7 @@ public class Decontextualize extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Decontextualize obj = Run.initJc(new Decontextualize(), args);
+			Decontextualize obj = CliRunner.initJc(new Decontextualize(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Decontextualize.java
+++ b/src/main/java/org/nanopub/op/Decontextualize.java
@@ -1,39 +1,25 @@
 package org.nanopub.op;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.eclipse.rdf4j.rio.*;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 import org.nanopub.op.fingerprint.FingerprintHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
-import net.trustyuri.TrustyUriException;
-
-public class Decontextualize {
+public class Decontextualize extends CliRunner {
 
 	public static final IRI graphPlaceholer = SimpleValueFactory.getInstance().createIRI("http://purl.org/nanopub/placeholders/graph");
 
@@ -47,17 +33,11 @@ public class Decontextualize {
 	private String inFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Decontextualize obj = new Decontextualize();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Decontextualize obj = Run.initJc(new Decontextualize(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/ExportJson.java
+++ b/src/main/java/org/nanopub/op/ExportJson.java
@@ -1,15 +1,7 @@
 package org.nanopub.op;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
@@ -18,18 +10,16 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
-import net.trustyuri.TrustyUriException;
-
-public class ExportJson {
+public class ExportJson extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -42,26 +32,13 @@ public class ExportJson {
 
 	public static void main(String[] args) {
 		try {
-			ExportJson obj = init(args);
+			ExportJson obj = Run.initJc(new ExportJson(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
-		}
-	}
-
-	static ExportJson init(String[] args) {
-		ExportJson obj = new ExportJson();
-		JCommander jc = new JCommander(obj);
-		try {
-			NanopubImpl.ensureLoaded();
-			jc.parse(args);
-			return obj;
-		} catch (ParameterException ex) {
-			jc.usage();
-			throw ex;
 		}
 	}
 

--- a/src/main/java/org/nanopub/op/ExportJson.java
+++ b/src/main/java/org/nanopub/op/ExportJson.java
@@ -10,9 +10,11 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -32,7 +34,7 @@ public class ExportJson extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			ExportJson obj = Run.initJc(new ExportJson(), args);
+			ExportJson obj = CliRunner.initJc(new ExportJson(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Extract.java
+++ b/src/main/java/org/nanopub/op/Extract.java
@@ -5,9 +5,11 @@ import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.*;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 
 import java.io.*;
 import java.nio.charset.Charset;
@@ -46,7 +48,7 @@ public class Extract extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Extract obj = Run.initJc(new Extract(), args);
+			Extract obj = CliRunner.initJc(new Extract(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Extract.java
+++ b/src/main/java/org/nanopub/op/Extract.java
@@ -1,34 +1,21 @@
 package org.nanopub.op;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.*;
+import org.nanopub.*;
+import org.nanopub.Run;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+
+import java.io.*;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriException;
-
-public class Extract {
+public class Extract extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -58,17 +45,11 @@ public class Extract {
 	private String outFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Extract obj = new Extract();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Extract obj = Run.initJc(new Extract(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Filter.java
+++ b/src/main/java/org/nanopub/op/Filter.java
@@ -1,20 +1,7 @@
 package org.nanopub.op;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
@@ -24,19 +11,19 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
-import net.trustyuri.TrustyUriException;
-
-public class Filter {
+public class Filter extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -66,17 +53,11 @@ public class Filter {
 	private String outFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Filter obj = new Filter();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Filter obj = Run.initJc(new Filter(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Filter.java
+++ b/src/main/java/org/nanopub/op/Filter.java
@@ -12,7 +12,6 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.*;
-import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 
 import java.io.*;
@@ -54,7 +53,7 @@ public class Filter extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Filter obj = Run.initJc(new Filter(), args);
+			Filter obj = CliRunner.initJc(new Filter(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Fingerprint.java
+++ b/src/main/java/org/nanopub/op/Fingerprint.java
@@ -6,9 +6,11 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 import org.nanopub.op.fingerprint.DefaultFingerprints;
 import org.nanopub.op.fingerprint.FingerprintHandler;
 
@@ -42,7 +44,7 @@ public class Fingerprint extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Fingerprint obj = Run.initJc(new Fingerprint(), args);
+			Fingerprint obj = CliRunner.initJc(new Fingerprint(), args);
 			obj.init();
 			obj.run();
 		} catch (ParameterException ex) {
@@ -59,7 +61,7 @@ public class Fingerprint extends CliRunner {
 		if (args == null) {
 			args = "";
 		}
-		Fingerprint obj = Run.initJc(new Fingerprint(), args.trim().split(" "));
+		Fingerprint obj = CliRunner.initJc(new Fingerprint(), args.trim().split(" "));
 		obj.init();
 		return obj;
 	}

--- a/src/main/java/org/nanopub/op/Fingerprint.java
+++ b/src/main/java/org/nanopub/op/Fingerprint.java
@@ -1,33 +1,23 @@
 package org.nanopub.op;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
-
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.op.fingerprint.DefaultFingerprints;
-import org.nanopub.op.fingerprint.FingerprintHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
+import org.nanopub.*;
+import org.nanopub.Run;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.op.fingerprint.DefaultFingerprints;
+import org.nanopub.op.fingerprint.FingerprintHandler;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
-public class Fingerprint {
+public class Fingerprint extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs")
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -51,30 +41,25 @@ public class Fingerprint {
 	private String handlerClass;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Fingerprint obj = new Fingerprint();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		obj.init();
-		try {
+			Fingerprint obj = Run.initJc(new Fingerprint(), args);
+			obj.init();
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
 		}
 	}
 
+	private Fingerprint() {}
+
 	public static Fingerprint getInstance(String args) throws ParameterException {
-		NanopubImpl.ensureLoaded();
-		if (args == null) args = "";
-		Fingerprint obj = new Fingerprint();
-		JCommander jc = new JCommander(obj);
-		jc.parse(args.trim().split(" "));
+		if (args == null) {
+			args = "";
+		}
+		Fingerprint obj = Run.initJc(new Fingerprint(), args.trim().split(" "));
 		obj.init();
 		return obj;
 	}

--- a/src/main/java/org/nanopub/op/Gml.java
+++ b/src/main/java/org/nanopub/op/Gml.java
@@ -1,35 +1,25 @@
 package org.nanopub.op;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
 
-import net.trustyuri.TrustyUriException;
-
-public class Gml {
+public class Gml extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -41,17 +31,11 @@ public class Gml {
 	private String inFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Gml obj = new Gml();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Gml obj = Run.initJc(new Gml(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Gml.java
+++ b/src/main/java/org/nanopub/op/Gml.java
@@ -8,9 +8,11 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -32,7 +34,7 @@ public class Gml extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Gml obj = Run.initJc(new Gml(), args);
+			Gml obj = CliRunner.initJc(new Gml(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Import.java
+++ b/src/main/java/org/nanopub/op/Import.java
@@ -9,7 +9,6 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
-import org.nanopub.Run;
 import org.nanopub.*;
 
 import java.io.*;
@@ -38,7 +37,7 @@ public class Import extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Import obj = Run.initJc(new Import(), args);
+			Import obj = CliRunner.initJc(new Import(), args);
 			if (obj.inputFiles.size() != 1) {
 				obj.getJc().usage();
 				System.exit(1);

--- a/src/main/java/org/nanopub/op/Import.java
+++ b/src/main/java/org/nanopub/op/Import.java
@@ -1,44 +1,25 @@
 package org.nanopub.op;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
+import org.eclipse.rdf4j.rio.*;
+import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
+import org.nanopub.Run;
+import org.nanopub.*;
+
+import java.io.*;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandler;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFParser;
-import org.eclipse.rdf4j.rio.Rio;
-import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubCreator;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
-import org.nanopub.SimpleCreatorPattern;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriException;
-
-public class Import {
+public class Import extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-file", required = true)
 	private List<File> inputFiles = new ArrayList<File>();
@@ -56,21 +37,15 @@ public class Import {
 	private String outFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Import obj = new Import();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		if (obj.inputFiles.size() != 1) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Import obj = Run.initJc(new Import(), args);
+			if (obj.inputFiles.size() != 1) {
+				obj.getJc().usage();
+				System.exit(1);
+			}
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/IndexReuse.java
+++ b/src/main/java/org/nanopub/op/IndexReuse.java
@@ -9,7 +9,6 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.*;
-import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 import org.nanopub.extra.index.IndexUtils;
 import org.nanopub.extra.index.NanopubIndex;
@@ -66,7 +65,7 @@ public class IndexReuse extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			IndexReuse obj = Run.initJc(new IndexReuse(), args);
+			IndexReuse obj = CliRunner.initJc(new IndexReuse(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/IndexReuse.java
+++ b/src/main/java/org/nanopub/op/IndexReuse.java
@@ -1,43 +1,29 @@
 package org.nanopub.op;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
 import org.nanopub.extra.index.IndexUtils;
 import org.nanopub.extra.index.NanopubIndex;
 import org.nanopub.extra.index.NanopubIndexCreator;
 import org.nanopub.extra.index.SimpleIndexCreator;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriException;
-
-public class IndexReuse {
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+public class IndexReuse extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopub-cache", required = true)
 	private List<File> inputNanopubCache = new ArrayList<File>();
@@ -79,17 +65,11 @@ public class IndexReuse {
 	private List<String> seeAlso = new ArrayList<>();
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		IndexReuse obj = new IndexReuse();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			IndexReuse obj = Run.initJc(new IndexReuse(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Namespaces.java
+++ b/src/main/java/org/nanopub/op/Namespaces.java
@@ -1,36 +1,24 @@
 package org.nanopub.op;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriException;
-
-public class Namespaces {
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.GZIPOutputStream;
+public class Namespaces extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs")
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -60,18 +48,12 @@ public class Namespaces {
 	private String inFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Namespaces obj = new Namespaces();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		obj.init();
-		try {
+			Namespaces obj = Run.initJc(new Namespaces(), args);
+			obj.init();
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -79,12 +61,10 @@ public class Namespaces {
 	}
 
 	public static Namespaces getInstance(String args) throws ParameterException {
-		NanopubImpl.ensureLoaded();
-		if (args == null) args = "";
-		Namespaces obj = new Namespaces();
-		JCommander jc = new JCommander(obj);
-		jc.parse(args.trim().split(" "));
-		obj.init();
+		if (args == null) {
+			args = "";
+		}
+		Namespaces obj = Run.initJc(new Namespaces(), args.trim().split(" "));
 		return obj;
 	}
 

--- a/src/main/java/org/nanopub/op/Namespaces.java
+++ b/src/main/java/org/nanopub/op/Namespaces.java
@@ -8,9 +8,11 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -49,7 +51,7 @@ public class Namespaces extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Namespaces obj = Run.initJc(new Namespaces(), args);
+			Namespaces obj = CliRunner.initJc(new Namespaces(), args);
 			obj.init();
 			obj.run();
 		} catch (ParameterException ex) {
@@ -64,7 +66,7 @@ public class Namespaces extends CliRunner {
 		if (args == null) {
 			args = "";
 		}
-		Namespaces obj = Run.initJc(new Namespaces(), args.trim().split(" "));
+		Namespaces obj = CliRunner.initJc(new Namespaces(), args.trim().split(" "));
 		return obj;
 	}
 

--- a/src/main/java/org/nanopub/op/Reuse.java
+++ b/src/main/java/org/nanopub/op/Reuse.java
@@ -1,20 +1,8 @@
 package org.nanopub.op;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.PrintStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import net.trustyuri.TrustyUriUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -22,22 +10,20 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubRdfHandler;
-import org.nanopub.NanopubUtils;
 import org.nanopub.trusty.FixTrustyNanopub;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 
-import net.trustyuri.TrustyUriException;
-import net.trustyuri.TrustyUriUtils;
-
-public class Reuse {
+public class Reuse extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -79,18 +65,12 @@ public class Reuse {
 	private String topicOptions;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Reuse obj = new Reuse();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		obj.init();
-		try {
+			Reuse obj = Run.initJc(new Reuse(), args);
+			obj.init();
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Reuse.java
+++ b/src/main/java/org/nanopub/op/Reuse.java
@@ -11,7 +11,6 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.*;
-import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 import org.nanopub.trusty.FixTrustyNanopub;
 
@@ -66,7 +65,7 @@ public class Reuse extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Reuse obj = Run.initJc(new Reuse(), args);
+			Reuse obj = CliRunner.initJc(new Reuse(), args);
 			obj.init();
 			obj.run();
 		} catch (ParameterException ex) {

--- a/src/main/java/org/nanopub/op/Run.java
+++ b/src/main/java/org/nanopub/op/Run.java
@@ -1,18 +1,14 @@
 package org.nanopub.op;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.rio.RDFParserRegistry;
 import org.eclipse.rdf4j.rio.RDFWriterRegistry;
 import org.eclipse.rdf4j.rio.turtle.TurtleParserFactory;
 import org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory;
 import org.nanopub.NanopubImpl;
+
+import java.io.IOException;
+import java.util.*;
 
 public class Run {
 

--- a/src/main/java/org/nanopub/op/Tar.java
+++ b/src/main/java/org/nanopub/op/Tar.java
@@ -1,12 +1,8 @@
 package org.nanopub.op;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import net.trustyuri.TrustyUriUtils;
 import org.apache.commons.codec.Charsets;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -14,20 +10,18 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.nanopub.*;
+import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
-import net.trustyuri.TrustyUriException;
-import net.trustyuri.TrustyUriUtils;
-
-public class Tar {
+public class Tar extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -39,17 +33,11 @@ public class Tar {
 	private String inFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Tar obj = new Tar();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Tar obj = Run.initJc(new Tar(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Tar.java
+++ b/src/main/java/org/nanopub/op/Tar.java
@@ -11,7 +11,6 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.*;
-import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 
 import java.io.BufferedOutputStream;
@@ -34,7 +33,7 @@ public class Tar extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Tar obj = Run.initJc(new Tar(), args);
+			Tar obj = CliRunner.initJc(new Tar(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Topic.java
+++ b/src/main/java/org/nanopub/op/Topic.java
@@ -1,32 +1,22 @@
 package org.nanopub.op;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
-
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.op.topic.DefaultTopics;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
+import org.nanopub.*;
+import org.nanopub.Run;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.op.topic.DefaultTopics;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
-public class Topic {
+public class Topic extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs")
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -44,18 +34,11 @@ public class Topic {
 	private String handlerClass;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Topic obj = new Topic();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		obj.init();
-		try {
+			Topic obj = Run.initJc(new Topic(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);
@@ -63,12 +46,10 @@ public class Topic {
 	}
 
 	public static Topic getInstance(String args) throws ParameterException {
-		NanopubImpl.ensureLoaded();
-		if (args == null) args = "";
-		Topic obj = new Topic();
-		JCommander jc = new JCommander(obj);
-		jc.parse(args.trim().split(" "));
-		obj.init();
+		if (args == null) {
+			args = "";
+		}
+		Topic obj = Run.initJc(new Topic(), args.trim().split(" "));
 		return obj;
 	}
 

--- a/src/main/java/org/nanopub/op/Topic.java
+++ b/src/main/java/org/nanopub/op/Topic.java
@@ -6,9 +6,11 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.*;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+import org.nanopub.Nanopub;
 import org.nanopub.op.topic.DefaultTopics;
 
 import java.io.*;
@@ -35,7 +37,7 @@ public class Topic extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Topic obj = Run.initJc(new Topic(), args);
+			Topic obj = CliRunner.initJc(new Topic(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);
@@ -49,7 +51,7 @@ public class Topic extends CliRunner {
 		if (args == null) {
 			args = "";
 		}
-		Topic obj = Run.initJc(new Topic(), args.trim().split(" "));
+		Topic obj = CliRunner.initJc(new Topic(), args.trim().split(" "));
 		return obj;
 	}
 

--- a/src/main/java/org/nanopub/op/Union.java
+++ b/src/main/java/org/nanopub/op/Union.java
@@ -7,7 +7,6 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.*;
-import org.nanopub.Run;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 
 import java.io.File;
@@ -36,7 +35,7 @@ public class Union extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			Union obj = Run.initJc(new Union(), args);
+			Union obj = CliRunner.initJc(new Union(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/op/Union.java
+++ b/src/main/java/org/nanopub/op/Union.java
@@ -1,5 +1,15 @@
 package org.nanopub.op;
 
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.Rio;
+import org.nanopub.*;
+import org.nanopub.Run;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -10,23 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubUtils;
-
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
-
-import net.trustyuri.TrustyUriException;
-
-public class Union {
+public class Union extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -41,17 +35,11 @@ public class Union {
 	private String outFormat;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		Union obj = new Union();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			Union obj = Run.initJc(new Union(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/trusty/FixTrustyNanopub.java
+++ b/src/main/java/org/nanopub/trusty/FixTrustyNanopub.java
@@ -26,7 +26,7 @@ public class FixTrustyNanopub extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			FixTrustyNanopub obj = Run.initJc(new FixTrustyNanopub(), args);
+			FixTrustyNanopub obj = CliRunner.initJc(new FixTrustyNanopub(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/main/java/org/nanopub/trusty/FixTrustyNanopub.java
+++ b/src/main/java/org/nanopub/trusty/FixTrustyNanopub.java
@@ -1,41 +1,22 @@
 package org.nanopub.trusty;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.zip.GZIPOutputStream;
-
+import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import net.trustyuri.TrustyUriResource;
 import net.trustyuri.TrustyUriUtils;
 import net.trustyuri.rdf.RdfFileContent;
 import net.trustyuri.rdf.RdfUtils;
-
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
+import org.eclipse.rdf4j.rio.*;
+import org.nanopub.*;
 import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubRdfHandler;
-import org.nanopub.NanopubUtils;
-import org.nanopub.NanopubWithNs;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
 
-public class FixTrustyNanopub {
+public class FixTrustyNanopub extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopubs", required = true)
 	private List<File> inputNanopubs = new ArrayList<File>();
@@ -44,17 +25,11 @@ public class FixTrustyNanopub {
 	private boolean verbose = false;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		FixTrustyNanopub obj = new FixTrustyNanopub();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			FixTrustyNanopub obj = Run.initJc(new FixTrustyNanopub(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/trusty/MakeTrustyNanopub.java
+++ b/src/main/java/org/nanopub/trusty/MakeTrustyNanopub.java
@@ -1,46 +1,23 @@
 package org.nanopub.trusty;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.zip.GZIPOutputStream;
-
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.eclipse.rdf4j.rio.RDFHandlerException;
-import org.eclipse.rdf4j.rio.RDFParseException;
-import org.eclipse.rdf4j.rio.RDFWriter;
-import org.eclipse.rdf4j.rio.Rio;
-import org.nanopub.MalformedNanopubException;
-import org.nanopub.MultiNanopubRdfHandler;
-import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
-import org.nanopub.Nanopub;
-import org.nanopub.NanopubImpl;
-import org.nanopub.NanopubRdfHandler;
-import org.nanopub.NanopubUtils;
-import org.nanopub.NanopubWithNs;
-
-import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-
 import net.trustyuri.TrustyUriException;
 import net.trustyuri.TrustyUriResource;
 import net.trustyuri.TrustyUriUtils;
 import net.trustyuri.rdf.RdfFileContent;
 import net.trustyuri.rdf.TransformRdf;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.rio.*;
+import org.nanopub.*;
+import org.nanopub.MultiNanopubRdfHandler.NanopubHandler;
 
-public class MakeTrustyNanopub {
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.*;
+import java.util.zip.GZIPOutputStream;
+
+public class MakeTrustyNanopub extends CliRunner {
 
 	@com.beust.jcommander.Parameter(description = "input-nanopub-files", required = true)
 	private List<File> inputNanopubsFiles = new ArrayList<File>();
@@ -58,17 +35,11 @@ public class MakeTrustyNanopub {
 	private boolean verbose = false;
 
 	public static void main(String[] args) {
-		NanopubImpl.ensureLoaded();
-		MakeTrustyNanopub obj = new MakeTrustyNanopub();
-		JCommander jc = new JCommander(obj);
 		try {
-			jc.parse(args);
-		} catch (ParameterException ex) {
-			jc.usage();
-			System.exit(1);
-		}
-		try {
+			MakeTrustyNanopub obj = Run.initJc(new MakeTrustyNanopub(), args);
 			obj.run();
+		} catch (ParameterException ex) {
+			System.exit(1);
 		} catch (Exception ex) {
 			ex.printStackTrace();
 			System.exit(1);

--- a/src/main/java/org/nanopub/trusty/MakeTrustyNanopub.java
+++ b/src/main/java/org/nanopub/trusty/MakeTrustyNanopub.java
@@ -36,7 +36,7 @@ public class MakeTrustyNanopub extends CliRunner {
 
 	public static void main(String[] args) {
 		try {
-			MakeTrustyNanopub obj = Run.initJc(new MakeTrustyNanopub(), args);
+			MakeTrustyNanopub obj = CliRunner.initJc(new MakeTrustyNanopub(), args);
 			obj.run();
 		} catch (ParameterException ex) {
 			System.exit(1);

--- a/src/test/java/org/nanopub/CheckInvalidNanopubsTest.java
+++ b/src/test/java/org/nanopub/CheckInvalidNanopubsTest.java
@@ -1,9 +1,9 @@
 package org.nanopub;
 
-import java.io.File;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.nanopub.CheckNanopub.Report;
+
+import java.io.File;
 
 public class CheckInvalidNanopubsTest {
  
@@ -23,7 +23,7 @@ public class CheckInvalidNanopubsTest {
 	public void testPlain(String filename) throws Exception {
 		Report report = null;
 		try {
-			CheckNanopub c = new CheckNanopub("src/main/resources/testsuite/invalid/plain/" + filename);
+			CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/plain/" + filename});
 			report = c.check();
 			System.out.println(report.getSummary());
 		} catch (Exception ex) {}
@@ -33,7 +33,7 @@ public class CheckInvalidNanopubsTest {
 	public void testTrusty(String filename) throws Exception {
 		Report report = null;
 		try {
-			CheckNanopub c = new CheckNanopub("src/main/resources/testsuite/invalid/trusty/" + filename);
+			CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/trusty/" + filename});
 			report = c.check();
 			System.out.println(report.getSummary());
 		} catch (Exception ex) {}
@@ -43,7 +43,7 @@ public class CheckInvalidNanopubsTest {
 	public void testSigned(String filename) throws Exception {
 		Report report = null;
 		try {
-			CheckNanopub c = new CheckNanopub("src/main/resources/testsuite/invalid/signed/" + filename);
+			CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/signed/" + filename});
 			report = c.check();
 			System.out.println(report.getSummary());
 		} catch (Exception ex) {}

--- a/src/test/java/org/nanopub/CheckInvalidNanopubsTest.java
+++ b/src/test/java/org/nanopub/CheckInvalidNanopubsTest.java
@@ -23,7 +23,7 @@ public class CheckInvalidNanopubsTest {
 	public void testPlain(String filename) throws Exception {
 		Report report = null;
 		try {
-			CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/plain/" + filename});
+			CheckNanopub c = CliRunner.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/plain/" + filename});
 			report = c.check();
 			System.out.println(report.getSummary());
 		} catch (Exception ex) {}
@@ -33,7 +33,7 @@ public class CheckInvalidNanopubsTest {
 	public void testTrusty(String filename) throws Exception {
 		Report report = null;
 		try {
-			CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/trusty/" + filename});
+			CheckNanopub c = CliRunner.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/trusty/" + filename});
 			report = c.check();
 			System.out.println(report.getSummary());
 		} catch (Exception ex) {}
@@ -43,7 +43,7 @@ public class CheckInvalidNanopubsTest {
 	public void testSigned(String filename) throws Exception {
 		Report report = null;
 		try {
-			CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/signed/" + filename});
+			CheckNanopub c = CliRunner.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/invalid/signed/" + filename});
 			report = c.check();
 			System.out.println(report.getSummary());
 		} catch (Exception ex) {}

--- a/src/test/java/org/nanopub/CheckValidNanopubsTest.java
+++ b/src/test/java/org/nanopub/CheckValidNanopubsTest.java
@@ -1,9 +1,9 @@
 package org.nanopub;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.nanopub.CheckNanopub.Report;
+
+import java.io.File;
 
 public class CheckValidNanopubsTest {
  
@@ -21,21 +21,21 @@ public class CheckValidNanopubsTest {
 	}
 
 	public void testPlain(String filename) throws Exception {
-		CheckNanopub c = new CheckNanopub("src/main/resources/testsuite/valid/plain/" + filename);
+		CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/plain/" + filename});
 		Report report = c.check();
 		System.out.println(report.getSummary());
 		assert report.areAllValid();
 	}
 
 	public void testTrusty(String filename) throws Exception {
-		CheckNanopub c = new CheckNanopub("src/main/resources/testsuite/valid/trusty/" + filename);
+		CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/trusty/" + filename});
 		Report report = c.check();
 		System.out.println(report.getSummary());
 		assert report.areAllTrusty();
 	}
 
 	public void testSigned(String filename) throws Exception {
-		CheckNanopub c = new CheckNanopub("src/main/resources/testsuite/valid/signed/" + filename);
+		CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/signed/" + filename});
 		Report report = c.check();
 		System.out.println(report.getSummary());
 		assert report.areAllSigned();

--- a/src/test/java/org/nanopub/CheckValidNanopubsTest.java
+++ b/src/test/java/org/nanopub/CheckValidNanopubsTest.java
@@ -21,21 +21,21 @@ public class CheckValidNanopubsTest {
 	}
 
 	public void testPlain(String filename) throws Exception {
-		CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/plain/" + filename});
+		CheckNanopub c = CliRunner.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/plain/" + filename});
 		Report report = c.check();
 		System.out.println(report.getSummary());
 		assert report.areAllValid();
 	}
 
 	public void testTrusty(String filename) throws Exception {
-		CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/trusty/" + filename});
+		CheckNanopub c = CliRunner.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/trusty/" + filename});
 		Report report = c.check();
 		System.out.println(report.getSummary());
 		assert report.areAllTrusty();
 	}
 
 	public void testSigned(String filename) throws Exception {
-		CheckNanopub c = Run.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/signed/" + filename});
+		CheckNanopub c = CliRunner.initJc(new CheckNanopub(), new String[] {"src/main/resources/testsuite/valid/signed/" + filename});
 		Report report = c.check();
 		System.out.println(report.getSummary());
 		assert report.areAllSigned();

--- a/src/test/java/org/nanopub/NanopubUtilsTest.java
+++ b/src/test/java/org/nanopub/NanopubUtilsTest.java
@@ -2,27 +2,18 @@ package org.nanopub;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
-import org.eclipse.rdf4j.model.util.Statements;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
-import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.rio.RDFFormat;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.nanopub.extra.index.NanopubIndex;
-import org.nanopub.trusty.TrustyNanopubUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class NanopubUtilsTest {

--- a/src/test/java/org/nanopub/extra/security/MakeKeysTest.java
+++ b/src/test/java/org/nanopub/extra/security/MakeKeysTest.java
@@ -2,7 +2,7 @@ package org.nanopub.extra.security;
 
 import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Test;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -10,14 +10,14 @@ class MakeKeysTest {
 
     @Test
     void initWithoutParams() {
-        Run.initJc(new MakeKeys(), new String[0]);
+        CliRunner.initJc(new MakeKeys(), new String[0]);
         // LATER we may test if keys at default location don't get overwritten
     }
 
     @Test
     void initInvalidParams() {
         assertThrows(ParameterException.class, () -> {
-            Run.initJc(new MakeKeys(), new String[] { "AnyWrong" });
+            CliRunner.initJc(new MakeKeys(), new String[] { "AnyWrong" });
         });
     }
 
@@ -25,15 +25,15 @@ class MakeKeysTest {
     void initValidParams() {
 
         // sig alg specified
-        Run.initJc(new MakeKeys(), new String[] { "-a", "RSA" });
-        Run.initJc(new MakeKeys(), new String[] { "-a", "DSA" });
+        CliRunner.initJc(new MakeKeys(), new String[] { "-a", "RSA" });
+        CliRunner.initJc(new MakeKeys(), new String[] { "-a", "DSA" });
 
         // path specified
         final String homeFolder = System.getProperty("user.home"); // Windows compatible since Java 8
-        Run.initJc(new MakeKeys(), new String[] { "-f", homeFolder });
+        CliRunner.initJc(new MakeKeys(), new String[] { "-f", homeFolder });
 
         // both specified
-        Run.initJc(new MakeKeys(), new String[] { "-a", "DSA", "-f", homeFolder });
+        CliRunner.initJc(new MakeKeys(), new String[] { "-a", "DSA", "-f", homeFolder });
     }
 
     // for now, we expect the making of keys is tested elsewhere

--- a/src/test/java/org/nanopub/extra/security/MakeKeysTest.java
+++ b/src/test/java/org/nanopub/extra/security/MakeKeysTest.java
@@ -1,25 +1,23 @@
 package org.nanopub.extra.security;
 
 import com.beust.jcommander.ParameterException;
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
+import org.nanopub.Run;
 
-import java.util.ArrayList;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MakeKeysTest {
 
     @Test
     void initWithoutParams() {
-        MakeKeys.init(new String[0]);
+        Run.initJc(new MakeKeys(), new String[0]);
         // LATER we may test if keys at default location don't get overwritten
     }
 
     @Test
     void initInvalidParams() {
         assertThrows(ParameterException.class, () -> {
-            MakeKeys.init(new String[] { "AnyWrong" });
+            Run.initJc(new MakeKeys(), new String[] { "AnyWrong" });
         });
     }
 
@@ -27,15 +25,15 @@ class MakeKeysTest {
     void initValidParams() {
 
         // sig alg specified
-        MakeKeys.init(new String[] { "-a", "RSA" });
-        MakeKeys.init(new String[] { "-a", "DSA" });
+        Run.initJc(new MakeKeys(), new String[] { "-a", "RSA" });
+        Run.initJc(new MakeKeys(), new String[] { "-a", "DSA" });
 
         // path specified
         final String homeFolder = System.getProperty("user.home"); // Windows compatible since Java 8
-        MakeKeys.init(new String[] { "-f", homeFolder });
+        Run.initJc(new MakeKeys(), new String[] { "-f", homeFolder });
 
         // both specified
-        MakeKeys.init(new String[] { "-a", "DSA", "-f", homeFolder });
+        Run.initJc(new MakeKeys(), new String[] { "-a", "DSA", "-f", homeFolder });
     }
 
     // for now, we expect the making of keys is tested elsewhere

--- a/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
@@ -2,34 +2,25 @@ package org.nanopub.extra.security;
 
 import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Test;
+import org.nanopub.Run;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 class SignNanopubTest {
 
     @Test
     void initWithoutArgs() throws IOException {
-        String[] args = new String[0];
-        try {
-            SignNanopub obj = SignNanopub.init(args);
-            fail("Should have thrown a Parameter exception (Which main translates to Exit Code: 1)");
-        } catch (ParameterException e) {
-            // We assume the Usage String printed out
-            System.out.println("All good!");
-            System.out.println(e.getMessage());
-            assertTrue(true);
-        }
-
+        assertThrowsExactly(ParameterException.class, () -> Run.initJc(new SignNanopub(), new String[0]));
     }
 
     @Test
     void initWithValidArgs() throws Exception {
-        String[] args = new String[] {"-v", "/Users/zip/repos/pixels/nanopub-java/src/main/resources/testsuite/valid/plain/aida1.trig"};
+        String path = "src/main/resources/testsuite/valid/plain/aida1.trig";
+        String[] args = new String[] {"-v", path};
 
-        SignNanopub obj = SignNanopub.init(args);
+        Run.initJc(new SignNanopub(), args);
     }
 
     // For now we assume, that most signing issues were detected by other tests

--- a/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
@@ -2,7 +2,7 @@ package org.nanopub.extra.security;
 
 import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Test;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
 
 import java.io.IOException;
 
@@ -12,7 +12,7 @@ class SignNanopubTest {
 
     @Test
     void initWithoutArgs() throws IOException {
-        assertThrowsExactly(ParameterException.class, () -> Run.initJc(new SignNanopub(), new String[0]));
+        assertThrowsExactly(ParameterException.class, () -> CliRunner.initJc(new SignNanopub(), new String[0]));
     }
 
     @Test
@@ -20,7 +20,7 @@ class SignNanopubTest {
         String path = "src/main/resources/testsuite/valid/plain/aida1.trig";
         String[] args = new String[] {"-v", path};
 
-        Run.initJc(new SignNanopub(), args);
+        CliRunner.initJc(new SignNanopub(), args);
     }
 
     // For now we assume, that most signing issues were detected by other tests

--- a/src/test/java/org/nanopub/op/ExportJsonTest.java
+++ b/src/test/java/org/nanopub/op/ExportJsonTest.java
@@ -2,9 +2,10 @@ package org.nanopub.op;
 
 import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Test;
-import org.nanopub.extra.security.MakeKeys;
+import org.nanopub.Run;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test the initialization of ExportJson.
@@ -15,7 +16,7 @@ class ExportJsonTest {
     @Test
     void initNoArgs() throws Exception {
         assertThrows(ParameterException.class, () -> {
-            ExportJson.init(new String[0]);
+            Run.initJc(new ExportJson(), new String[0]);
         });
     }
 
@@ -30,13 +31,13 @@ class ExportJsonTest {
 
     @Test
     void initValidArgs() throws Exception {
-        ExportJson obj = ExportJson.init(new String[] {"inputFile"});
+        ExportJson obj = Run.initJc(new ExportJson(), new String[] {"inputFile"});
         assertNotNull(obj);
 
-        obj = ExportJson.init(new String[] {"inputFile", "-o", "outputFile"});
+        obj = Run.initJc(new ExportJson(), new String[] {"inputFile", "-o", "outputFile"});
         assertNotNull(obj);
 
-        obj = ExportJson.init(new String[] {"inputFile", "--in-format", "trig"});
+        obj = Run.initJc(new ExportJson(), new String[] {"inputFile", "--in-format", "trig"});
         assertNotNull(obj);
     }
 

--- a/src/test/java/org/nanopub/op/ExportJsonTest.java
+++ b/src/test/java/org/nanopub/op/ExportJsonTest.java
@@ -2,7 +2,7 @@ package org.nanopub.op;
 
 import com.beust.jcommander.ParameterException;
 import org.junit.jupiter.api.Test;
-import org.nanopub.Run;
+import org.nanopub.CliRunner;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,7 +16,7 @@ class ExportJsonTest {
     @Test
     void initNoArgs() throws Exception {
         assertThrows(ParameterException.class, () -> {
-            Run.initJc(new ExportJson(), new String[0]);
+            CliRunner.initJc(new ExportJson(), new String[0]);
         });
     }
 
@@ -31,13 +31,13 @@ class ExportJsonTest {
 
     @Test
     void initValidArgs() throws Exception {
-        ExportJson obj = Run.initJc(new ExportJson(), new String[] {"inputFile"});
+        ExportJson obj = CliRunner.initJc(new ExportJson(), new String[] {"inputFile"});
         assertNotNull(obj);
 
-        obj = Run.initJc(new ExportJson(), new String[] {"inputFile", "-o", "outputFile"});
+        obj = CliRunner.initJc(new ExportJson(), new String[] {"inputFile", "-o", "outputFile"});
         assertNotNull(obj);
 
-        obj = Run.initJc(new ExportJson(), new String[] {"inputFile", "--in-format", "trig"});
+        obj = CliRunner.initJc(new ExportJson(), new String[] {"inputFile", "--in-format", "trig"});
         assertNotNull(obj);
     }
 


### PR DESCRIPTION
All the cli commands now inherit from a base class CliRunner.java. The JCommander initialization is handled from a static method in that base class, resulting in less code duplication.