### PR TITLE
Add transitive dependency on jakarta activation to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
       <version>3.12.14</version>
     </dependency>
     <dependency>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>2.1.3</version>
+    </dependency>
+    <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
       <version>4.0.2</version>


### PR DESCRIPTION
Similar to https://github.com/trustyuri/trustyuri-java/pull/12, this PR migrates the xml-bind and activation dependencies from javax to jakarta. Javax has been deprecated for several years now and has since been unmaintained (see [Maven](https://mvnrepository.com/artifact/javax.activation/activation)). The reason I'm making this PR is that we want to use the [nanopub-java](https://github.com/Nanopublication/nanopub-java) library in the [ORKG](https://orkg.org/). The problem arises when gathering all dependencies. The ORKG backend is based on the latest spring version, which uses jakarta libraries. The nanopub library depends on javax libraries. However, because of capability resolution, we can only have either jakarta, or javax libraries in our classpath, while the latter is breaking spring libraries. The only way to fix the issue, is to migrate the dependencies of the nanopub (and trustyuri) libraries from javax to jakarta. This PR also explicitly declares a dependency on jakarta.activation, because parts of it are used in the source code of nanopub. ~I'm leaving this PR as a draft for now because it requires an updated version of the trustyuri library that uses jakarta dependencies.~