### PR TITLE
Upgrade Jelly-JVM to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@
       <version>1.22</version>
     </dependency>
     <dependency>
-      <groupId>eu.ostrzyciel.jelly</groupId>
-      <artifactId>jelly-rdf4j_3</artifactId>
-      <version>2.9.1</version>
+      <groupId>eu.neverblink.jelly</groupId>
+      <artifactId>jelly-rdf4j</artifactId>
+      <version>3.1.0</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/src/main/java/org/nanopub/jelly/JellyUtils.java
+++ b/src/main/java/org/nanopub/jelly/JellyUtils.java
@@ -10,7 +10,6 @@ import eu.neverblink.jelly.core.proto.v1.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.rio.RDFFormat;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubImpl;
@@ -21,19 +20,10 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.stream.Stream;
 
-import static eu.neverblink.jelly.convert.rdf4j.rio.JellyFormat.JELLY;
-
 /**
  * Utility functions for working with Jelly RDF data.
  */
 public class JellyUtils {
-
-    /**
-     * Jelly RDF format for use with RDF4J Rio.
-     */
-    public static final RDFFormat JELLY_FORMAT = JELLY;
-
-    public static final RdfStreamOptions defaultSupportedOptions = JellyOptions.DEFAULT_SUPPORTED_OPTIONS;
 
     /**
      * Options for Jelly RDF streams that are written to the database.
@@ -147,6 +137,6 @@ public class JellyUtils {
             }
         };
 
-        return Rdf4jConverterFactory.getInstance().quadsDecoder(handler, defaultSupportedOptions);
+        return Rdf4jConverterFactory.getInstance().quadsDecoder(handler, JellyOptions.DEFAULT_SUPPORTED_OPTIONS);
     }
 }

--- a/src/main/java/org/nanopub/jelly/JellyUtils.java
+++ b/src/main/java/org/nanopub/jelly/JellyUtils.java
@@ -1,10 +1,12 @@
 package org.nanopub.jelly;
 
-import eu.ostrzyciel.jelly.convert.rdf4j.Rdf4jConverterFactory$;
-import eu.ostrzyciel.jelly.convert.rdf4j.rio.package$;
-import eu.ostrzyciel.jelly.core.JellyOptions$;
-import eu.ostrzyciel.jelly.core.ProtoDecoder;
-import eu.ostrzyciel.jelly.core.proto.v1.*;
+import com.google.protobuf.InvalidProtocolBufferException;
+import eu.neverblink.jelly.convert.rdf4j.Rdf4jConverterFactory;
+import eu.neverblink.jelly.convert.rdf4j.Rdf4jDatatype;
+import eu.neverblink.jelly.core.JellyOptions;
+import eu.neverblink.jelly.core.ProtoDecoder;
+import eu.neverblink.jelly.core.RdfHandler;
+import eu.neverblink.jelly.core.proto.v1.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
@@ -13,14 +15,13 @@ import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubUtils;
-import scala.Option;
-import scala.Some;
-import scala.jdk.CollectionConverters;
-import scala.runtime.BoxedUnit;
 
+import java.io.IOException;
 import java.io.InputStream;
-import java.util.Vector;
+import java.util.ArrayList;
 import java.util.stream.Stream;
+
+import static eu.neverblink.jelly.convert.rdf4j.rio.JellyFormat.JELLY;
 
 /**
  * Utility functions for working with Jelly RDF data.
@@ -30,24 +31,25 @@ public class JellyUtils {
     /**
      * Jelly RDF format for use with RDF4J Rio.
      */
-    public final static RDFFormat JELLY_FORMAT = package$.MODULE$.JELLY();
+    public static final RDFFormat JELLY_FORMAT = JELLY;
 
-    public final static Option<RdfStreamOptions> defaultSupportedOptions =
-        Some.apply(JellyOptions$.MODULE$.defaultSupportedOptions());
+    public static final RdfStreamOptions defaultSupportedOptions = JellyOptions.DEFAULT_SUPPORTED_OPTIONS;
 
     /**
      * Options for Jelly RDF streams that are written to the database.
      */
-    public static RdfStreamOptions jellyOptionsForDB = JellyOptions$.MODULE$.smallStrict()
-        .withPhysicalType(PhysicalStreamType.QUADS$.MODULE$)
-        .withLogicalType(LogicalStreamType.DATASETS$.MODULE$);
+    public static final RdfStreamOptions jellyOptionsForDB = JellyOptions.SMALL_STRICT
+        .clone()
+        .setPhysicalType(PhysicalStreamType.QUADS)
+        .setLogicalType(LogicalStreamType.DATASETS);
 
     /**
      * Options for Jelly RDF streams that are transmitted between services.
      */
-    public static RdfStreamOptions jellyOptionsForTransmission = JellyOptions$.MODULE$.bigStrict()
-        .withPhysicalType(PhysicalStreamType.QUADS$.MODULE$)
-        .withLogicalType(LogicalStreamType.DATASETS$.MODULE$);
+    public static final RdfStreamOptions jellyOptionsForTransmission = JellyOptions.BIG_STRICT
+        .clone()
+        .setPhysicalType(PhysicalStreamType.QUADS)
+        .setLogicalType(LogicalStreamType.DATASETS);
 
     /**
      * Write a Nanopub to bytes in the Jelly format to be stored in the database.
@@ -72,8 +74,12 @@ public class JellyUtils {
      * @throws MalformedNanopubException if this is not a valid Nanopub
      */
     public static Nanopub readFromDB(byte[] jellyBytes) throws MalformedNanopubException {
-        RdfStreamFrame frame = RdfStreamFrame$.MODULE$.parseFrom(jellyBytes);
-        return readFromFrame(frame);
+        try {
+            RdfStreamFrame frame = RdfStreamFrame.parseFrom(jellyBytes);
+            return readFromFrame(frame);
+        } catch (InvalidProtocolBufferException e) {
+            throw new MalformedNanopubException("Failed to parse Jelly RDF bytes as a Nanopub: " + e.getMessage());
+        }
     }
 
     /**
@@ -84,33 +90,39 @@ public class JellyUtils {
      * @throws MalformedNanopubException if this is not a valid Nanopub
      */
     public static Nanopub readFromInputStream(InputStream is) throws MalformedNanopubException {
-        RdfStreamFrame frame = RdfStreamFrame$.MODULE$.parseDelimitedFrom(is).get();
-        return readFromFrame(frame);
+        try {
+            RdfStreamFrame frame = RdfStreamFrame.parseDelimitedFrom(is);
+            return readFromFrame(frame);
+        } catch (IOException e) {
+            throw new MalformedNanopubException("Failed to read Jelly RDF from InputStream: " + e.getMessage());
+        }
     }
 
     static Nanopub readFromFrame(RdfStreamFrame frame) throws MalformedNanopubException {
-        final Vector<Statement> statements = new Vector<>();
-        final Vector<Pair<String, String>> namespaces = new Vector<>();
-        final ProtoDecoder<Statement> decoder = getDecoder(namespaces);
+        final ArrayList<Statement> statements = new ArrayList<>();
+        final ArrayList<Pair<String, String>> namespaces = new ArrayList<>();
 
-        parseStatements(frame, decoder, statements);
+        final var decoder = getDecoder(statements, namespaces);
+        frame.getRows().forEach(decoder::ingestRow);
+
         return new NanopubImpl(statements, namespaces);
     }
 
     static Stream<MaybeNanopub> readFromFrameStream(Stream<RdfStreamFrame> frameStream) {
-        final Vector<Statement> statements = new Vector<>();
-        final Vector<Pair<String, String>> namespaces = new Vector<>();
-        final ProtoDecoder<Statement> decoder = getDecoder(namespaces);
+        final ArrayList<Statement> statements = new ArrayList<>();
+        final ArrayList<Pair<String, String>> namespaces = new ArrayList<>();
+        final var decoder = getDecoder(statements, namespaces);
 
         return frameStream.map(frame -> {
             try {
                 statements.clear();
                 namespaces.clear();
-                parseStatements(frame, decoder, statements);
+
+                frame.getRows().forEach(decoder::ingestRow);
                 return new MaybeNanopub(
                         new NanopubImpl(statements, namespaces),
                         // Extract the counter metadata from the frame
-                        JellyMetadataUtil.tryGetCounterFromMetadata(frame.metadata())
+                        JellyMetadataUtil.tryGetCounterFromMetadata(frame.getMetadata())
                 );
             } catch (MalformedNanopubException e) {
                 return new MaybeNanopub(e);
@@ -118,24 +130,23 @@ public class JellyUtils {
         });
     }
 
-    private static ProtoDecoder<Statement> getDecoder(Vector<Pair<String, String>> namespaces) {
-        return Rdf4jConverterFactory$.MODULE$.quadsDecoder(
-                defaultSupportedOptions,
-                ((String prefix, Value node) -> {
-                    namespaces.add(Pair.of(prefix, node.stringValue()));
-                    return BoxedUnit.UNIT;
-                })
-        );
-    }
-
-    private static void parseStatements(
-            RdfStreamFrame frame, ProtoDecoder<Statement> decoder, Vector<Statement> statements
+    private static ProtoDecoder<Value, Rdf4jDatatype> getDecoder(
+        ArrayList<Statement> statements,
+        ArrayList<Pair<String, String>> namespaces
     ) {
-        CollectionConverters.SeqHasAsJava(frame.rows()).asJava().forEach(row -> {
-            Statement maybeSt = (Statement) decoder.ingestRowFlat(row);
-            if (maybeSt != null) {
-                statements.add(maybeSt);
+        final var quadMaker = Rdf4jConverterFactory.getInstance().decoderConverter();
+        final var handler = new RdfHandler.QuadHandler<Value>() {
+            @Override
+            public void handleNamespace(String prefix, Value namespace) {
+                namespaces.add(Pair.of(prefix, namespace.stringValue()));
             }
-        });
+
+            @Override
+            public void handleQuad(Value subject, Value predicate, Value object, Value graph) {
+                statements.add(quadMaker.makeQuad(subject, predicate, object, graph));
+            }
+        };
+
+        return Rdf4jConverterFactory.getInstance().quadsDecoder(handler, defaultSupportedOptions);
     }
 }

--- a/src/test/java/org/nanopub/jelly/JellyMetadataUtilTest.java
+++ b/src/test/java/org/nanopub/jelly/JellyMetadataUtilTest.java
@@ -1,10 +1,10 @@
 package org.nanopub.jelly;
 
 import com.google.protobuf.ByteString;
+import eu.neverblink.jelly.core.proto.v1.RdfStreamFrame;
 import org.junit.Test;
-import scala.Some$;
-import scala.Tuple2;
-import scala.collection.immutable.Map$;
+
+import java.util.List;
 
 public class JellyMetadataUtilTest {
 
@@ -16,28 +16,28 @@ public class JellyMetadataUtilTest {
 
         for (long testCase : testCases) {
             var m = JellyMetadataUtil.getCounterMetadata(testCase);
-            assert m.contains(JellyMetadataUtil.COUNTER_KEY);
-            assert m.size() == 1;
+            assert m.getKey().equals(JellyMetadataUtil.COUNTER_KEY);
+            assert m.getValue() != null;
             // Parsing
-            var counter = JellyMetadataUtil.tryGetCounterFromMetadata(m);
+            var counter = JellyMetadataUtil.tryGetCounterFromMetadata(List.of(m));
             assert counter == testCase;
         }
     }
 
     @Test
     public void testGetCounterNoKey() {
-        var m = (Object) Map$.MODULE$.empty();
-        var counter = JellyMetadataUtil.tryGetCounterFromMetadata(
-                (scala.collection.immutable.Map<String, ByteString>) m
-        );
+        var counter = JellyMetadataUtil.tryGetCounterFromMetadata(List.of());
         assert counter == -1;
     }
 
     @Test
     public void testGetCounterEmptyArray() {
-        var m = scala.collection.immutable.Map.from(Some$.MODULE$.apply(
-                Tuple2.apply(JellyMetadataUtil.COUNTER_KEY, ByteString.copyFrom(new byte[0]))
-        ));
+        var m = List.<RdfStreamFrame.MetadataEntry>of(
+                RdfStreamFrame.MetadataEntry.newInstance()
+                    .setKey(JellyMetadataUtil.COUNTER_KEY)
+                    .setValue(ByteString.copyFrom(new byte[0]))
+        );
+
         var counter = JellyMetadataUtil.tryGetCounterFromMetadata(m);
         assert counter == -1;
     }

--- a/src/test/java/org/nanopub/jelly/JellyWriterRDFHandlerTest.java
+++ b/src/test/java/org/nanopub/jelly/JellyWriterRDFHandlerTest.java
@@ -10,9 +10,9 @@ public class JellyWriterRDFHandlerTest {
                 JellyUtils.jellyOptionsForDB
         );
         var frame = handler.getFrame();
-        assert frame.rows().isEmpty();
-        assert frame.metadata() != null;
-        assert frame.metadata() == JellyMetadataUtil.EMPTY_METADATA;
+        assert frame.getRows().isEmpty();
+        assert frame.getMetadata() != null;
+        assert frame.getMetadata().isEmpty();
     }
 
     @Test
@@ -21,11 +21,10 @@ public class JellyWriterRDFHandlerTest {
                 JellyUtils.jellyOptionsForDB
         );
         var frame = handler.getFrame(42);
-        assert frame.rows().isEmpty();
-        assert frame.metadata() != null;
-        assert frame.metadata().contains(JellyMetadataUtil.COUNTER_KEY);
-        assert frame.metadata().size() == 1;
-        var counter = JellyMetadataUtil.tryGetCounterFromMetadata(frame.metadata());
+        assert frame.getRows().isEmpty();
+        assert frame.getMetadata() != null;
+        assert frame.getMetadata().size() == 1;
+        var counter = JellyMetadataUtil.tryGetCounterFromMetadata(frame.getMetadata());
         assert counter == 42;
     }
 }


### PR DESCRIPTION
This PR upgrades the Jelly-JVM version to 3.1.0 and migrates the codebase to support this version. As a result of the move of Jelly-JVM project away from Scala-based implementation for core modules, the code no longer depends on Scala runtime and becomes much more native-looking.

Both registry and query were tested with a local build of nanopubs:

Registry:
![image](https://github.com/user-attachments/assets/13bfe39f-de24-42bc-a6cf-9c962b1e6507)
![image](https://github.com/user-attachments/assets/16d5bf61-bb4f-436d-a125-c79cc8ed4b46)

Query:
![image](https://github.com/user-attachments/assets/6d1ae009-6d9a-4a46-bc46-3fc9c6404689)

Once this PR is merged and the library artefacts become available in the repository, PRs for registry and query will be made.