### PR TITLE
Add more helper functions to Nanopub interface

### DIFF
--- a/src/main/java/org/nanopub/Nanopub.java
+++ b/src/main/java/org/nanopub/Nanopub.java
@@ -10,6 +10,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.nanopub.extra.server.PublishNanopub;
 
 /**
  * @author Tobias Kuhn
@@ -64,5 +65,13 @@ public interface Nanopub {
 
 	public default String writeToString(RDFFormat format) throws RDFHandlerException, IOException {
 		return NanopubUtils.writeToString(this, format);
+	}
+
+	public default String publish() throws IOException {
+		return PublishNanopub.publish(this);
+	}
+
+	public default String publish(String serverUrl) throws IOException {
+		return PublishNanopub.publish(this, serverUrl);
 	}
 }

--- a/src/main/java/org/nanopub/Nanopub.java
+++ b/src/main/java/org/nanopub/Nanopub.java
@@ -2,14 +2,19 @@ package org.nanopub;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.security.InvalidKeyException;
+import java.security.SignatureException;
 import java.util.Calendar;
 import java.util.Set;
 
+import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.nanopub.extra.security.SignNanopub;
+import org.nanopub.extra.security.TransformContext;
 import org.nanopub.extra.server.PublishNanopub;
 
 /**
@@ -73,5 +78,9 @@ public interface Nanopub {
 
 	public default String publish(String serverUrl) throws IOException {
 		return PublishNanopub.publish(this, serverUrl);
+	}
+
+	public default Nanopub sign(TransformContext context) throws TrustyUriException, SignatureException, InvalidKeyException {
+		return SignNanopub.signAndTransform(this, context);
 	}
 }


### PR DESCRIPTION
This PR adds some more helper functions to the `Nanopub` interface, allowing for a more fluent DSL usage:

```java
var npCreator = NanopubCreator();
// build nanopub instance
npCreator.finalizeNanopub(true)
    .sign(TransformContext.makeDefault())
    .publish("some server url here")
```