### PR TITLE
Add getNs method to `NanopubWithNs` interface

### DIFF
--- a/src/main/java/org/nanopub/NanopubImpl.java
+++ b/src/main/java/org/nanopub/NanopubImpl.java
@@ -501,6 +501,7 @@ public class NanopubImpl implements NanopubWithNs, Serializable {
 	/**
 	 * @return a copy of the namespaces map
 	 */
+	@Override
 	public Map<String, String> getNs() {
 		return new HashMap<>(ns);
 	}

--- a/src/main/java/org/nanopub/NanopubWithNs.java
+++ b/src/main/java/org/nanopub/NanopubWithNs.java
@@ -1,6 +1,7 @@
 package org.nanopub;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * This extension of the interface represents nanopub objects that store prefix/namespace mappings.
@@ -11,8 +12,9 @@ public interface NanopubWithNs extends Nanopub {
 
 	public List<String> getNsPrefixes();
 
+	public Map<String, String> getNs();
+
 	public String getNamespace(String prefix);
 
 	public void removeUnusedPrefixes();
-
 }

--- a/src/main/java/org/nanopub/extra/index/NanopubIndexImpl.java
+++ b/src/main/java/org/nanopub/extra/index/NanopubIndexImpl.java
@@ -1,10 +1,8 @@
 package org.nanopub.extra.index;
 
-import java.util.Calendar;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
+import com.google.common.collect.ImmutableMap;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
@@ -225,4 +223,12 @@ public class NanopubIndexImpl implements NanopubIndex, NanopubWithNs {
 		}
 	}
 
+	@Override
+	public Map<String, String> getNs() {
+		if (np instanceof NanopubWithNs) {
+			return ((NanopubWithNs) np).getNs();
+		} else {
+			return ImmutableMap.of();
+		}
+	}
 }


### PR DESCRIPTION
This PR adds the `getNs` method, which was already implemented in the `NanopubImpl` class, to the `NanopubWithNs` interface. That makes it easier to handle namespaces on Nanopub(WithNs) instances.

I also want to point out the following issue:
It is possible to instantiate a `NanopubImpl` instance with prefixes that do not have a backing namespace. You can use the first constructor of `NanopubImpl` for that. This is not per see an issue, but the following pattern is present multiple times in the codebase:
```java
NanopubWithNs npNs = (NanopubWithNs) np;
for (String prefix : npNs.getNsPrefixes()) { // get list of prefixes
    htmlWriter.handleNamespace(prefix, npNs.getNamespace(prefix)); // lookup value by prefix
}
```
Because of the issue, the above code could throw an NPE, because the prefix is registered, but no backing value exists. With this PR, it is possible to replace this pattern the following way:
```java
NanopubWithNs npNs = (NanopubWithNs) np;
for (var ns : npNs.getNs().entrySet()) { // iterate over entry set
    htmlWriter.handleNamespace(ns.getKey(), ns.getValue()); // directly access required values
}
```
This should prevent accidental NPEs and should be more efficient in general. As a side effect, the methods `getNsPrefixes` and `getNamespace` could be removed from the `NanopubWithNs` interfaces, as well as the `nsPrefixes` list from `NanopubImpl`.