### PR TITLE
Removed unneeded depedency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <rdf4j.version>5.1.3</rdf4j.version>
+    <rdf4j.version>5.1.4</rdf4j.version>
   </properties>
   <dependencies>
     <dependency>
@@ -86,11 +86,6 @@
       <groupId>org.commonjava.mimeparse</groupId>
       <artifactId>mimeparse</artifactId>
       <version>0.1.3.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.14</version>
     </dependency>
     <dependency>
       <groupId>net.trustyuri</groupId>


### PR DESCRIPTION
This PR was meant to implement https://github.com/Nanopublication/nanopub-java/issues/50 but it turns out that the direct depedency was redundant and that removing it does not give warnings with `mvn clean install` and neither with `mvnw -B test`.

However, it also does not remove the httpclient 4 depedency, as it is indirectly pulled in via RDF4j:

```
+- org.eclipse.rdf4j:rdf4j-rio-jsonld:jar:5.1.4:compile
|  +- no.hasmac:hasmac-json-ld:jar:0.9.0:compile
|  |  \- org.glassfish:jakarta.json:jar:2.0.1:compile
|  +- jakarta.json:jakarta.json-api:jar:2.0.1:compile
|  +- org.glassfish:jakarta.json:jar:module:2.0.1:compile
|  +- org.apache.httpcomponents:httpclient:jar:4.5.14:compile
|  |  \- org.apache.httpcomponents:httpcore:jar:4.4.16:compile
|  +- org.apache.httpcomponents:httpclient-cache:jar:4.5.14:compile
|  +- org.slf4j:jcl-over-slf4j:jar:1.7.36:runtime
|  \- com.fasterxml.jackson.core:jackson-core:jar:2.13.5:compile
```

Eclipse RDF4j is thinking about upgrading but it does not seem to have been implemented yet: https://github.com/eclipse-rdf4j/rdf4j/issues/4472