### PR TITLE
Fix issue with round-tripping Jelly blobs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>eu.neverblink.jelly</groupId>
       <artifactId>jelly-rdf4j</artifactId>
-      <version>3.5.0</version>
+      <version>3.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/src/test/java/org/nanopub/jelly/JellyUtilsTest.java
+++ b/src/test/java/org/nanopub/jelly/JellyUtilsTest.java
@@ -1,0 +1,20 @@
+package org.nanopub.jelly;
+
+import org.junit.jupiter.api.Test;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubImpl;
+
+import java.io.File;
+import java.io.IOException;
+
+public class JellyUtilsTest {
+
+    @Test
+    public void testDbRoundTrip() throws MalformedNanopubException, IOException {
+        Nanopub np = new NanopubImpl(new File("./src/test/resources/fdo/validPerson.trig"));
+        byte[] bytes = JellyUtils.writeNanopubForDB(np);
+        Nanopub np2 = JellyUtils.readFromDB(bytes);
+        assert np.equals(np2);
+    }
+}


### PR DESCRIPTION
In Jelly-JVM < 3.5.2 there was an issue with how datatypes were constructed – we were accidentally breaking an under-documented RDF4J contract. The latest release fixes that.

See: https://github.com/Jelly-RDF/jelly-jvm/pull/534

I've added a regression test for this – it fails with Jelly-JVM 3.5.1.