### PR TITLE
feat(vocabulary): add RootNanopubPlaceholder to NTEMPLATE

### DIFF
--- a/src/main/java/org/nanopub/vocabulary/NTEMPLATE.java
+++ b/src/main/java/org/nanopub/vocabulary/NTEMPLATE.java
@@ -102,6 +102,14 @@ public class NTEMPLATE {
     public static final IRI AGENT_PLACEHOLDER = VocabUtils.createIRI(NAMESPACE, "AgentPlaceholder");
 
     /**
+     * Represents the class for root nanopub placeholders. Placeholders of this type
+     * preserve their existing value on supersede/derive actions, and otherwise take
+     * the URI of the current nanopublication. Their value is fixed and not editable
+     * by the user.
+     */
+    public static final IRI ROOT_NANOPUB_PLACEHOLDER = VocabUtils.createIRI(NAMESPACE, "RootNanopubPlaceholder");
+
+    /**
      * Represents the placeholder for the creator.
      */
     public static final IRI CREATOR_PLACEHOLDER = VocabUtils.createIRI(NAMESPACE, "CREATOR");


### PR DESCRIPTION
## Summary
- Adds `nt:RootNanopubPlaceholder` to the `NTEMPLATE` vocabulary as `ROOT_NANOPUB_PLACEHOLDER`.
- Semantics (to be implemented in consumers such as nanodash): the placeholder's value is fixed (not user-editable); on supersede/derive it keeps the existing value, and otherwise defaults to the URI of the current nanopublication.

## Test plan
- [ ] Consumer (nanodash) can reference `NTEMPLATE.ROOT_NANOPUB_PLACEHOLDER` after a snapshot bump.
- [ ] No existing tests reference `NTEMPLATE` placeholder constants, so no test updates are required here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)