### PR TITLE
feat(fdo): add FdoCreate CLI and recognise lowercase fdoProfile

### DIFF
--- a/src/main/java/org/nanopub/Run.java
+++ b/src/main/java/org/nanopub/Run.java
@@ -10,6 +10,7 @@ import org.nanopub.extra.server.NanopubStatus;
 import org.nanopub.extra.server.PublishNanopub;
 import org.nanopub.extra.services.RunQuery;
 import org.nanopub.extra.setting.ShowSetting;
+import org.nanopub.fdo.FdoCreate;
 import org.nanopub.fdo.ShaclValidator;
 import org.nanopub.trusty.FixTrustyNanopub;
 import org.nanopub.trusty.MakeTrustyNanopub;
@@ -74,6 +75,7 @@ public class Run {
         addRunnableClass(TimestampUpdater.class, "udtime");
         addRunnableClass(StripDown.class, "strip");
         addRunnableClass(ShaclValidator.class, "shacl");
+        addRunnableClass(FdoCreate.class, "fdo");
         addRunnableClass(RoCrateImporter.class, "rocrate");
         addRunnableClass(RoHubUpdater.class, "roupdate");
         addRunnableClass(NanopubRetractorCli.class, "retract");

--- a/src/main/java/org/nanopub/fdo/FdoCreate.java
+++ b/src/main/java/org/nanopub/fdo/FdoCreate.java
@@ -1,0 +1,84 @@
+package org.nanopub.fdo;
+
+import com.beust.jcommander.ParameterException;
+import net.trustyuri.TrustyUriException;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.nanopub.CliRunner;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubAlreadyFinalizedException;
+import org.nanopub.NanopubUtils;
+import org.nanopub.extra.security.SignNanopub;
+import org.nanopub.extra.security.TransformContext;
+import org.nanopub.extra.server.PublishNanopub;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.SignatureException;
+
+/**
+ * Create and optionally publish a nanopub for a handle-based FDO.
+ */
+public class FdoCreate extends CliRunner {
+
+    @com.beust.jcommander.Parameter(description = "handle-id", required = true)
+    private String handleId;
+
+    @com.beust.jcommander.Parameter(names = "-u", description = "Unsigned, the Nanopub is not signed. Do not use with -p.")
+    private boolean unsigned;
+
+    @com.beust.jcommander.Parameter(names = "-p", description = "Directly publish the Nanopub.")
+    private boolean publish;
+
+    /**
+     * Main method to run the FdoCreate command-line tool.
+     *
+     * @param args command line arguments, expects a handle identifier
+     */
+    public static void main(String[] args) {
+        try {
+            FdoCreate obj = CliRunner.initJc(new FdoCreate(), args);
+            obj.run();
+        } catch (ParameterException ex) {
+            System.exit(1);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Resolves the handle and creates a nanopub from it, then either prints or publishes it.
+     *
+     * @throws org.nanopub.MalformedNanopubException        if the nanopub is malformed
+     * @throws java.io.IOException                          if there is an I/O error
+     * @throws java.net.URISyntaxException                  if the handle identifier is not a valid URI
+     * @throws java.lang.InterruptedException               if the thread is interrupted while resolving the handle
+     * @throws net.trustyuri.TrustyUriException             if there is an issue with Trusty URI
+     * @throws java.security.SignatureException             if there is an issue with signing the nanopub
+     * @throws java.security.InvalidKeyException            if the signing key is invalid
+     * @throws org.nanopub.NanopubAlreadyFinalizedException if the nanopub has already been finalized
+     */
+    public void run() throws MalformedNanopubException, IOException, URISyntaxException, InterruptedException,
+            TrustyUriException, SignatureException, InvalidKeyException, NanopubAlreadyFinalizedException {
+
+        if (unsigned && publish) {
+            System.err.println("Do not use -u and -p together.");
+            throw new ParameterException("Cannot use -u and -p together.");
+        }
+
+        Nanopub np = FdoNanopubCreator.createFromHandleSystem(handleId);
+
+        if (unsigned) {
+            NanopubUtils.writeToStream(np, System.out, RDFFormat.TRIG);
+        } else if (publish) {
+            Nanopub signedNp = SignNanopub.signAndTransform(np, TransformContext.makeDefault());
+            PublishNanopub.publish(signedNp);
+        } else {
+            Nanopub signedNp = SignNanopub.signAndTransform(np, TransformContext.makeDefault());
+            NanopubUtils.writeToStream(signedNp, System.out, RDFFormat.TRIG);
+        }
+    }
+
+}

--- a/src/main/java/org/nanopub/fdo/FdoNanopubCreator.java
+++ b/src/main/java/org/nanopub/fdo/FdoNanopubCreator.java
@@ -109,17 +109,21 @@ public class FdoNanopubCreator {
      * @throws java.io.IOException            if there is an error during the HTTP request to the handle system
      * @throws java.lang.InterruptedException if the thread is interrupted while waiting for the HTTP request to complete
      */
-    public static FdoRecord createFdoRecordFromHandleSystem(String id) throws URISyntaxException, IOException, InterruptedException {
+    public static FdoRecord createFdoRecordFromHandleSystem(String id) throws URISyntaxException, IOException, InterruptedException, MalformedNanopubException {
         ParsedJsonResponse response = new HandleResolver().call(id);
         FdoRecord record = initFdoRecord(response);
+        if (record.getAttribute(org.eclipse.rdf4j.model.vocabulary.DCTERMS.CONFORMS_TO) == null) {
+            throw new MalformedNanopubException("Handle record for '" + id + "' has no recognised FDO profile type (expected one of: "
+                    + PROFILE_HANDLE + ", " + PROFILE_HANDLE_1 + ", " + PROFILE_HANDLE_2 + ", " + PROFILE_HANDLE_3 + ")");
+        }
 
         for (Value v : response.values) {
             if (v.type.equals(DATA_REF_HANDLE)) {
                 record.setAttribute(FDOF.IS_MATERIALIZED_BY, vf.createIRI(String.valueOf(v.data.value)));
                 continue;
             }
-            if (!v.type.equals("HS_ADMIN") && !v.type.equals("name") && !v.type.equals("id") && !v.type.equals(PROFILE_HANDLE) && !v.type.equals(PROFILE_HANDLE_1) && !v.type.equals(PROFILE_HANDLE_2)) {
-                // TODO later remove PROFILE_HANDLE_1 and PROFILE_HANDLE_2
+            if (!v.type.equals("HS_ADMIN") && !v.type.equals("name") && !v.type.equals("id") && !v.type.equals(PROFILE_HANDLE) && !v.type.equals(PROFILE_HANDLE_1) && !v.type.equals(PROFILE_HANDLE_2) && !v.type.equals(PROFILE_HANDLE_3)) {
+                // TODO later remove PROFILE_HANDLE_1, PROFILE_HANDLE_2 and PROFILE_HANDLE_3
                 String dataValue = String.valueOf(v.data.value);
                 String dataValueToImport;
                 if (looksLikeHandle(dataValue)) {
@@ -151,8 +155,8 @@ public class FdoNanopubCreator {
             if (v.type.equals("name")) {
                 label = String.valueOf(v.data.value);
             }
-            if (v.type.equals(PROFILE_HANDLE) || v.type.equals(PROFILE_HANDLE_1) || v.type.equals(PROFILE_HANDLE_2)) {
-                // TODO later remove PROFILE_HANDLE_1 and PROFILE_HANDLE_2
+            if (v.type.equals(PROFILE_HANDLE) || v.type.equals(PROFILE_HANDLE_1) || v.type.equals(PROFILE_HANDLE_2) || v.type.equals(PROFILE_HANDLE_3)) {
+                // TODO later remove PROFILE_HANDLE_1, PROFILE_HANDLE_2 and PROFILE_HANDLE_3
                 String profileValue = String.valueOf(v.data.value);
                 if (looksLikeHandle(profileValue)) {
                     profile = toIri(profileValue);

--- a/src/main/java/org/nanopub/fdo/FdoUtils.java
+++ b/src/main/java/org/nanopub/fdo/FdoUtils.java
@@ -33,6 +33,11 @@ public final class FdoUtils {
     public static final String PROFILE_HANDLE = "21.T11966/FdoProfile";
 
     /**
+     * The handle for the FDO profile (lowercase variant used by some handle services).
+     */
+    public static final String PROFILE_HANDLE_3 = "fdoProfile";
+
+    /**
      * The handle for the FDO data reference.
      */
     public static final String DATA_REF_HANDLE = "21.T11966/06a6c27e3e2ef27779ec";

--- a/src/test/java/org/nanopub/fdo/FdoNanopubCreatorTest.java
+++ b/src/test/java/org/nanopub/fdo/FdoNanopubCreatorTest.java
@@ -2,6 +2,8 @@ package org.nanopub.fdo;
 
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.PROV;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -201,7 +203,7 @@ public class FdoNanopubCreatorTest {
     }
 
     @Test
-    void createFdoRecordFromHandleSystem() throws URISyntaxException, IOException, InterruptedException {
+    void createFdoRecordFromHandleSystem() throws URISyntaxException, IOException, InterruptedException, MalformedNanopubException {
         String handle = "21.T11966/82045bd97a0acce88378";
         String handleSystemResponse = "{\"responseCode\":1,\"handle\":\"21.T11966/82045bd97a0acce88378\",\"values\":[{\"index\":100,\"type\":\"HS_ADMIN\",\"data\":{\"format\":\"admin\",\"value\":{\"handle\":\"0.NA/21.T11966\",\"index\":300,\"permissions\":\"111111111111\"}},\"ttl\":86400,\"timestamp\":\"2025-07-02T11:03:54Z\"},{\"index\":1,\"type\":\"10320/loc\",\"data\":{\"format\":\"string\",\"value\":\"<locations>\\n<location href=\\\"http://typeregistry.testbed.pid.gwdg.de/objects/21.T11966/82045bd97a0acce88378\\\" weight=\\\"0\\\" view=\\\"json\\\" />\\n<location href=\\\"http://typeregistry.testbed.pid.gwdg.de/#objects/21.T11966/82045bd97a0acce88378\\\" weight=\\\"1\\\" view=\\\"ui\\\" />\\n</locations>\"},\"ttl\":86400,\"timestamp\":\"2025-07-02T11:03:54Z\"},{\"index\":2,\"type\":\"21.T11966/FdoProfile\",\"data\":{\"format\":\"string\",\"value\":\"21.T11966/996c38676da9ee56f8ab\"},\"ttl\":86400,\"timestamp\":\"2025-07-02T11:03:54Z\"},{\"index\":3,\"type\":\"21.T11966/JsonSchema\",\"data\":{\"format\":\"string\",\"value\":\"{\\\"$ref\\\": \\\"https://typeapi.lab.pidconsortium.net/v1/types/schema/21.T11966/82045bd97a0acce88378\\\"}\"},\"ttl\":86400,\"timestamp\":\"2025-07-02T11:03:54Z\"},{\"index\":4,\"type\":\"21.T11966/b5b58656b1fa5aff0505\",\"data\":{\"format\":\"string\",\"value\":\"21.T11966/service\"},\"ttl\":86400,\"timestamp\":\"2025-07-02T11:03:54Z\"},{\"index\":5,\"type\":\"0.TYPE/DOIPService\",\"data\":{\"format\":\"string\",\"value\":\"21.T11966/service\"},\"ttl\":86400,\"timestamp\":\"2025-07-02T11:03:54Z\"}]}";
 
@@ -214,6 +216,100 @@ public class FdoNanopubCreatorTest {
 
             FdoRecord fdoRecord = FdoNanopubCreator.createFdoRecordFromHandleSystem(handle);
             assertNotNull(fdoRecord);
+        }
+    }
+
+    @Test
+    void createFdoRecordFromHandleSystem_recognisesLowercaseFdoProfile() throws Exception {
+        String handle = "20.5000.1025/J7E-C1H-1X2";
+        String handleSystemResponse = "{\"responseCode\":1,\"handle\":\"20.5000.1025/J7E-C1H-1X2\",\"values\":["
+                + "{\"index\":1,\"type\":\"fdoProfile\",\"data\":{\"format\":\"string\",\"value\":\"https://doi.org/21.T11148/2e76f544229901c5a942\"},\"ttl\":86400,\"timestamp\":\"2024-12-18T15:52:41Z\"},"
+                + "{\"index\":5,\"type\":\"digitalObjectName\",\"data\":{\"format\":\"string\",\"value\":\"Annotation\"},\"ttl\":86400,\"timestamp\":\"2024-12-18T15:52:41Z\"}"
+                + "]}";
+
+        HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
+        when(mockHttpResponse.body()).thenReturn(handleSystemResponse);
+        try (MockedStatic<HttpClient> httpClientStaticMock = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString()))).thenReturn(mockHttpResponse);
+            httpClientStaticMock.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            FdoRecord record = FdoNanopubCreator.createFdoRecordFromHandleSystem(handle);
+
+            assertEquals("https://doi.org/21.T11148/2e76f544229901c5a942", record.getProfile());
+            // The recognised profile field must not leak into the generic attribute map.
+            assertNull(record.getAttribute(iri(FdoNanopubCreator.FDO_TYPE_PREFIX + "fdoProfile")));
+        }
+    }
+
+    @Test
+    void createFdoRecordFromHandleSystem_throwsWhenProfileMissing() throws Exception {
+        String handle = "20.5000.1025/NO-PROFILE";
+        String handleSystemResponse = "{\"responseCode\":1,\"handle\":\"20.5000.1025/NO-PROFILE\",\"values\":["
+                + "{\"index\":5,\"type\":\"digitalObjectName\",\"data\":{\"format\":\"string\",\"value\":\"Annotation\"},\"ttl\":86400,\"timestamp\":\"2024-12-18T15:52:41Z\"}"
+                + "]}";
+
+        HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
+        when(mockHttpResponse.body()).thenReturn(handleSystemResponse);
+        try (MockedStatic<HttpClient> httpClientStaticMock = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString()))).thenReturn(mockHttpResponse);
+            httpClientStaticMock.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            MalformedNanopubException ex = assertThrows(MalformedNanopubException.class,
+                    () -> FdoNanopubCreator.createFdoRecordFromHandleSystem(handle));
+            assertTrue(ex.getMessage().contains(handle));
+            assertTrue(ex.getMessage().contains("fdoProfile"));
+        }
+    }
+
+    @Test
+    void createFromHandleSystem_buildsFdoNanopub() throws Exception {
+        String handle = "20.5000.1025/J7E-C1H-1X2";
+        String profileValue = "https://doi.org/21.T11148/2e76f544229901c5a942";
+        String handleSystemResponse = "{\"responseCode\":1,\"handle\":\"20.5000.1025/J7E-C1H-1X2\",\"values\":["
+                + "{\"index\":1,\"type\":\"fdoProfile\",\"data\":{\"format\":\"string\",\"value\":\"" + profileValue + "\"},\"ttl\":86400,\"timestamp\":\"2024-12-18T15:52:41Z\"},"
+                + "{\"index\":5,\"type\":\"digitalObjectName\",\"data\":{\"format\":\"string\",\"value\":\"Annotation\"},\"ttl\":86400,\"timestamp\":\"2024-12-18T15:52:41Z\"}"
+                + "]}";
+
+        HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
+        when(mockHttpResponse.body()).thenReturn(handleSystemResponse);
+        try (MockedStatic<HttpClient> httpClientStaticMock = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString()))).thenReturn(mockHttpResponse);
+            httpClientStaticMock.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            Nanopub np = FdoNanopubCreator.createFromHandleSystem(handle);
+
+            IRI fdoIri = FdoUtils.createIri(handle);
+            IRI derivedFrom = iri(HandleResolver.BASE_URI + handle);
+
+            boolean hasTypeStatement = np.getAssertion().stream().anyMatch(st ->
+                    st.getSubject().equals(fdoIri)
+                    && st.getPredicate().equals(RDF.TYPE)
+                    && st.getObject().equals(FDOF.FAIR_DIGITAL_OBJECT));
+            assertTrue(hasTypeStatement, "assertion must declare fdoIri a fdof:FAIRDigitalObject");
+
+            boolean hasConformsTo = np.getAssertion().stream().anyMatch(st ->
+                    st.getSubject().equals(fdoIri)
+                    && st.getPredicate().equals(DCTERMS.CONFORMS_TO)
+                    && st.getObject().equals(iri(profileValue)));
+            assertTrue(hasConformsTo, "assertion must carry dct:conformsTo for the profile");
+
+            boolean hasDerivedFrom = np.getProvenance().stream().anyMatch(st ->
+                    st.getPredicate().equals(PROV.WAS_DERIVED_FROM)
+                    && st.getObject().equals(derivedFrom));
+            assertTrue(hasDerivedFrom, "provenance must trace back to the handle API URL");
+
+            boolean introducesFdo = np.getPubinfo().stream().anyMatch(st ->
+                    st.getPredicate().equals(NPX.INTRODUCES)
+                    && st.getObject().equals(fdoIri));
+            assertTrue(introducesFdo, "pubinfo must introduce the FDO IRI");
+
+            // Sanity: all assertion statements have a non-null object.
+            for (Statement st : np.getAssertion()) {
+                assertNotNull(st.getObject(), "no null objects in assertion");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- New `fdo` subcommand (`FdoCreate`) that builds a nanopub for a handle-based FDO via `FdoNanopubCreator.createFromHandleSystem`. Flags mirror `RoCrateImporter`: default = sign and print as TriG, `-u` = print unsigned, `-p` = sign and publish.
- Recognise the lowercase `fdoProfile` handle type (used by production services such as DiSSCo) alongside the existing `FdoProfile` / `21.T11966/FdoProfile` / `0.FDO/Profile` variants. Without this, the profile field was missed, leaving `dct:conformsTo` null and crashing `FdoRecord.buildStatements` with an NPE.
- `createFdoRecordFromHandleSystem` now throws `MalformedNanopubException` with a clear message listing the accepted profile types when none is present, instead of leaving a downstream NPE.

## Example

```
$ np fdo -u 20.5000.1025/J7E-C1H-1X2

this:assertion {
  <https://hdl.handle.net/20.5000.1025/J7E-C1H-1X2> a fdof:FAIRDigitalObject;
    dct:conformsTo <https://doi.org/21.T11148/2e76f544229901c5a942>;
    ... .
}
```

## Test plan
- [x] `mvn test -Dtest=FdoNanopubCreatorTest` — 12 tests pass (9 existing + 3 new).
- [x] New tests cover: lowercase `fdoProfile` recognised; missing profile raises `MalformedNanopubException`; end-to-end `createFromHandleSystem` produces `fdof:FAIRDigitalObject` + `dct:conformsTo` + `prov:wasDerivedFrom` + `npx:introduces`.
- [x] Built the CLI fat jar (`mvn -Pcli package -DskipTests`) and verified `np fdo -u 20.5000.1025/J7E-C1H-1X2` prints the expected unsigned TriG (previously threw NPE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)