### PR TITLE
feat(fdo): schema enrichment, handle URLs, referentName label

### DIFF
--- a/src/main/java/org/nanopub/fdo/FdoCreate.java
+++ b/src/main/java/org/nanopub/fdo/FdoCreate.java
@@ -22,7 +22,7 @@ import java.security.SignatureException;
  */
 public class FdoCreate extends CliRunner {
 
-    @com.beust.jcommander.Parameter(description = "handle-id", required = true)
+    @com.beust.jcommander.Parameter(description = "handle-id-or-url", required = true)
     private String handleId;
 
     @com.beust.jcommander.Parameter(names = "-u", description = "Unsigned, the Nanopub is not signed. Do not use with -p.")
@@ -30,6 +30,9 @@ public class FdoCreate extends CliRunner {
 
     @com.beust.jcommander.Parameter(names = "-p", description = "Directly publish the Nanopub.")
     private boolean publish;
+
+    @com.beust.jcommander.Parameter(names = {"-s", "--enrich-from-schema"}, description = "Resolve the FDO profile's type registry entry and use property handles as predicates (with rdfs:label in pubinfo).")
+    private boolean enrichFromSchema;
 
     /**
      * Main method to run the FdoCreate command-line tool.
@@ -68,7 +71,13 @@ public class FdoCreate extends CliRunner {
             throw new ParameterException("Cannot use -u and -p together.");
         }
 
-        Nanopub np = FdoNanopubCreator.createFromHandleSystem(handleId);
+        String resolvedId = FdoUtils.extractHandleId(handleId);
+        if (resolvedId == null) {
+            System.err.println("Not a recognisable handle or handle/DOI URL: " + handleId);
+            throw new ParameterException("Not a recognisable handle or handle/DOI URL: " + handleId);
+        }
+
+        Nanopub np = FdoNanopubCreator.createFromHandleSystem(resolvedId, enrichFromSchema);
 
         if (unsigned) {
             NanopubUtils.writeToStream(np, System.out, RDFFormat.TRIG);

--- a/src/main/java/org/nanopub/fdo/FdoNanopubCreator.java
+++ b/src/main/java/org/nanopub/fdo/FdoNanopubCreator.java
@@ -4,8 +4,10 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.PROV;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubAlreadyFinalizedException;
@@ -20,6 +22,9 @@ import org.nanopub.vocabulary.NPX;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Random;
 
 import static org.nanopub.fdo.FdoUtils.*;
@@ -92,12 +97,53 @@ public class FdoNanopubCreator {
      * @throws org.nanopub.NanopubAlreadyFinalizedException if the Nanopub has already been finalized
      */
     public static Nanopub createFromHandleSystem(String id) throws MalformedNanopubException, URISyntaxException, IOException, InterruptedException, NanopubAlreadyFinalizedException {
-        FdoRecord record = createFdoRecordFromHandleSystem(id);
+        return createFromHandleSystem(id, false);
+    }
+
+    /**
+     * Creation of Nanopub from the handle system, optionally enriching predicates using the
+     * profile's Data Type Registry entry.
+     *
+     * <p>When {@code enrichFromSchema} is {@code true}, the FDO profile handle is resolved and its
+     * property list is used to turn handle-record field names into handle IRIs (predicates in the
+     * assertion). For each mapped predicate, an {@code rdfs:label} with the original field name is
+     * added to the pubinfo graph. If the profile schema cannot be resolved, behaviour falls back
+     * to the default mapping.</p>
+     *
+     * @param id               the handle system identifier
+     * @param enrichFromSchema whether to enrich predicates via the profile's DTR entry
+     * @return Nanopub containing the data from the handle system
+     * @throws org.nanopub.MalformedNanopubException        if the Nanopub cannot be created due to malformed data
+     * @throws java.net.URISyntaxException                  if the handle system identifier is not a valid URI
+     * @throws java.io.IOException                          if there is an error during the HTTP request to the handle system
+     * @throws java.lang.InterruptedException               if the thread is interrupted while waiting for the HTTP request to complete
+     * @throws org.nanopub.NanopubAlreadyFinalizedException if the Nanopub has already been finalized
+     */
+    public static Nanopub createFromHandleSystem(String id, boolean enrichFromSchema) throws MalformedNanopubException, URISyntaxException, IOException, InterruptedException, NanopubAlreadyFinalizedException {
+        ParsedJsonResponse response = new HandleResolver().call(id);
+        Map<IRI, String> labelSink = new LinkedHashMap<>();
+        FdoRecord record = buildFdoRecord(id, response, enrichFromSchema, labelSink);
 
         IRI fdoIri = FdoUtils.createIri(id);
         NanopubCreator creator = createWithFdoIri(record, fdoIri);
         creator.addProvenanceStatement(PROV.WAS_DERIVED_FROM, vf.createIRI(HandleResolver.BASE_URI + id));
+        for (Map.Entry<IRI, String> e : labelSink.entrySet()) {
+            creator.addPubinfoStatement(e.getKey(), RDFS.LABEL, vf.createLiteral(e.getValue()));
+        }
+        creator.addPubinfoStatement(fdoIri, RDFS.LABEL, vf.createLiteral(resolveFdoLabel(response, id)));
         return creator.finalizeNanopub(true);
+    }
+
+    private static String resolveFdoLabel(ParsedJsonResponse response, String id) {
+        if (response != null && response.values != null) {
+            for (Value v : response.values) {
+                if ("referentName".equals(v.type) && v.data != null && v.data.value != null) {
+                    String s = String.valueOf(v.data.value);
+                    if (!s.isEmpty()) return s;
+                }
+            }
+        }
+        return id;
     }
 
     /**
@@ -110,12 +156,38 @@ public class FdoNanopubCreator {
      * @throws java.lang.InterruptedException if the thread is interrupted while waiting for the HTTP request to complete
      */
     public static FdoRecord createFdoRecordFromHandleSystem(String id) throws URISyntaxException, IOException, InterruptedException, MalformedNanopubException {
+        return createFdoRecordFromHandleSystem(id, false, null);
+    }
+
+    /**
+     * Creates an FdoRecord from a handle system identifier, optionally enriching predicates
+     * via the profile's Data Type Registry entry.
+     *
+     * @param id               the handle system identifier
+     * @param enrichFromSchema whether to fetch the profile schema and map property names to handle IRIs
+     * @param labelSink        if non-null, populated with {@code predicateIri → originalName} pairs
+     *                         for every predicate sourced from the profile schema
+     * @return FdoRecord containing the data from the handle system
+     * @throws java.net.URISyntaxException            if the handle system identifier is not a valid URI
+     * @throws java.io.IOException                    if there is an error during the HTTP request to the handle system
+     * @throws java.lang.InterruptedException         if the thread is interrupted while waiting for the HTTP request to complete
+     * @throws org.nanopub.MalformedNanopubException  if the handle record has no recognised profile type
+     */
+    public static FdoRecord createFdoRecordFromHandleSystem(String id, boolean enrichFromSchema, Map<IRI, String> labelSink) throws URISyntaxException, IOException, InterruptedException, MalformedNanopubException {
         ParsedJsonResponse response = new HandleResolver().call(id);
+        return buildFdoRecord(id, response, enrichFromSchema, labelSink);
+    }
+
+    private static FdoRecord buildFdoRecord(String id, ParsedJsonResponse response, boolean enrichFromSchema, Map<IRI, String> labelSink) throws MalformedNanopubException {
         FdoRecord record = initFdoRecord(response);
-        if (record.getAttribute(org.eclipse.rdf4j.model.vocabulary.DCTERMS.CONFORMS_TO) == null) {
+        if (record.getAttribute(DCTERMS.CONFORMS_TO) == null) {
             throw new MalformedNanopubException("Handle record for '" + id + "' has no recognised FDO profile type (expected one of: "
                     + PROFILE_HANDLE + ", " + PROFILE_HANDLE_1 + ", " + PROFILE_HANDLE_2 + ", " + PROFILE_HANDLE_3 + ")");
         }
+
+        Map<String, IRI> nameToHandle = enrichFromSchema
+                ? FdoProfileSchemaLoader.loadPropertyMap((IRI) record.getAttribute(DCTERMS.CONFORMS_TO))
+                : new HashMap<>();
 
         for (Value v : response.values) {
             if (v.type.equals(DATA_REF_HANDLE)) {
@@ -132,7 +204,12 @@ public class FdoNanopubCreator {
                     dataValueToImport = dataValue;
                 }
                 IRI fdoHandleIri;
-                if (v.type.contains("/")) {
+                if (nameToHandle.containsKey(v.type)) {
+                    fdoHandleIri = nameToHandle.get(v.type);
+                    if (labelSink != null) {
+                        labelSink.putIfAbsent(fdoHandleIri, v.type);
+                    }
+                } else if (v.type.contains("/")) {
                     fdoHandleIri = vf.createIRI(HDL.NAMESPACE + v.type);
                 } else {
                     fdoHandleIri = vf.createIRI(FDO_TYPE_PREFIX + v.type);

--- a/src/main/java/org/nanopub/fdo/FdoProfileSchemaLoader.java
+++ b/src/main/java/org/nanopub/fdo/FdoProfileSchemaLoader.java
@@ -1,0 +1,155 @@
+package org.nanopub.fdo;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.nanopub.fdo.rest.HandleResolver;
+import org.nanopub.fdo.rest.gson.ParsedJsonResponse;
+import org.nanopub.fdo.rest.gson.Value;
+import org.nanopub.vocabulary.HDL;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Loads a property-name → handle-IRI mapping for an FDO profile by resolving the profile handle
+ * and fetching its entry from a Data Type Registry (DTR).
+ *
+ * <p>Two DTR JSON shapes are supported:</p>
+ * <ul>
+ *   <li>Array of <code>{"name": ..., "identifier": ...}</code> under <code>properties</code>
+ *       (e.g. DiSSCo / PID Consortium DTR).</li>
+ *   <li>Array of <code>{"Name": "&lt;handle&gt;", ...}</code> under <code>Schema.Properties</code>
+ *       (e.g. GWDG testbed).</li>
+ * </ul>
+ *
+ * <p>Resolution is best-effort: any failure along the way yields an empty map so the caller can
+ * fall back to default predicate construction.</p>
+ */
+public final class FdoProfileSchemaLoader {
+
+    private static final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private static final Pattern JSON_LOC_HREF = Pattern.compile(
+            "<location\\s+[^>]*href=\"([^\"]+)\"[^>]*view=\"json\"", Pattern.CASE_INSENSITIVE);
+
+    private FdoProfileSchemaLoader() {
+    }
+
+    /**
+     * Build a name → handle-IRI mapping for the given FDO profile.
+     *
+     * @param profileIri the profile IRI from the FdoRecord (may be a handle, handle URL, or DOI URL)
+     * @return a possibly-empty map of property name → handle IRI; never null
+     */
+    public static Map<String, IRI> loadPropertyMap(IRI profileIri) {
+        if (profileIri == null) return Map.of();
+        String handleId = FdoUtils.extractHandleId(profileIri.stringValue());
+        if (handleId == null) return Map.of();
+        try {
+            ParsedJsonResponse profile = new HandleResolver().call(handleId);
+            String jsonLoc = findJsonLocation(profile);
+            if (jsonLoc == null) return Map.of();
+            String body = httpGet(jsonLoc);
+            return parsePropertyMap(body);
+        } catch (Exception ignore) {
+            return Map.of();
+        }
+    }
+
+    static String findJsonLocation(ParsedJsonResponse profile) {
+        if (profile == null || profile.values == null) return null;
+        for (Value v : profile.values) {
+            if ("10320/loc".equals(v.type) && v.data != null && v.data.value != null) {
+                Matcher m = JSON_LOC_HREF.matcher(String.valueOf(v.data.value));
+                if (m.find()) return m.group(1);
+            }
+        }
+        return null;
+    }
+
+    static String httpGet(String url) throws Exception {
+        HttpRequest req = HttpRequest.newBuilder().GET().uri(new URI(url)).build();
+        HttpResponse<String> resp = HttpClient.newHttpClient().send(req, HttpResponse.BodyHandlers.ofString());
+        return resp.body();
+    }
+
+    static Map<String, IRI> parsePropertyMap(String json) {
+        Map<String, IRI> out = new HashMap<>();
+        JsonElement parsed = JsonParser.parseString(json);
+        if (!parsed.isJsonObject()) return out;
+        JsonObject root = parsed.getAsJsonObject();
+
+        if (root.has("properties")) {
+            JsonElement props = root.get("properties");
+            // DTR array shape: [{"name": ..., "identifier": ...}]
+            if (props.isJsonArray()) {
+                for (JsonElement el : props.getAsJsonArray()) {
+                    if (!el.isJsonObject()) continue;
+                    JsonObject p = el.getAsJsonObject();
+                    if (p.has("name") && p.has("identifier")) {
+                        String name = p.get("name").getAsString();
+                        String id = p.get("identifier").getAsString();
+                        if (FdoUtils.looksLikeHandle(id)) {
+                            IRI handleIri = vf.createIRI(HDL.NAMESPACE + id);
+                            out.putIfAbsent(name, handleIri);
+                            addTitleKey(out, p, handleIri);
+                        }
+                    }
+                }
+            }
+            // JSON Schema object shape: {"<handle>": {title: "..."}}
+            if (props.isJsonObject()) {
+                for (Map.Entry<String, JsonElement> e : props.getAsJsonObject().entrySet()) {
+                    String key = e.getKey();
+                    if (!FdoUtils.looksLikeHandle(key)) continue;
+                    IRI handleIri = vf.createIRI(HDL.NAMESPACE + key);
+                    out.putIfAbsent(key, handleIri);
+                    if (e.getValue().isJsonObject()) {
+                        addTitleKey(out, e.getValue().getAsJsonObject(), handleIri);
+                    }
+                }
+            }
+        }
+
+        if (root.has("Schema") && root.get("Schema").isJsonObject()) {
+            JsonObject schema = root.getAsJsonObject("Schema");
+            if (schema.has("Properties") && schema.get("Properties").isJsonArray()) {
+                for (JsonElement el : schema.getAsJsonArray("Properties")) {
+                    if (!el.isJsonObject()) continue;
+                    JsonObject p = el.getAsJsonObject();
+                    if (p.has("Name")) {
+                        String name = p.get("Name").getAsString();
+                        if (FdoUtils.looksLikeHandle(name)) {
+                            IRI handleIri = vf.createIRI(HDL.NAMESPACE + name);
+                            out.putIfAbsent(name, handleIri);
+                            addTitleKey(out, p, handleIri);
+                        }
+                    }
+                }
+            }
+        }
+
+        return out;
+    }
+
+    private static void addTitleKey(Map<String, IRI> out, JsonObject p, IRI handleIri) {
+        for (String field : new String[]{"Title", "title"}) {
+            if (p.has(field) && p.get(field).isJsonPrimitive()) {
+                String title = p.get(field).getAsString();
+                if (!title.isEmpty()) out.putIfAbsent(title, handleIri);
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/nanopub/fdo/FdoUtils.java
+++ b/src/main/java/org/nanopub/fdo/FdoUtils.java
@@ -104,6 +104,27 @@ public final class FdoUtils {
     }
 
     /**
+     * Strip a known prefix (hdl.handle.net, doi.org) from the given input and return the bare
+     * handle id, or return the input unchanged if it already looks like a handle.
+     *
+     * @param input a handle, a handle URL, or a DOI URL
+     * @return the bare handle id, or null if the input is not a recognisable handle
+     */
+    public static String extractHandleId(String input) {
+        if (input == null) return null;
+        String[] prefixes = {
+                "https://hdl.handle.net/",
+                "http://hdl.handle.net/",
+                "https://doi.org/",
+                "http://doi.org/"
+        };
+        for (String p : prefixes) {
+            if (input.startsWith(p)) return input.substring(p.length());
+        }
+        return looksLikeHandle(input) ? input : null;
+    }
+
+    /**
      * Create an IRI by prefixing a handle with <a href="https://hdl.handle.net/">...</a> if it's a handle,
      * or by just converting an url.
      *

--- a/src/test/java/org/nanopub/fdo/FdoNanopubCreatorTest.java
+++ b/src/test/java/org/nanopub/fdo/FdoNanopubCreatorTest.java
@@ -6,6 +6,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.PROV;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
@@ -310,6 +311,121 @@ public class FdoNanopubCreatorTest {
             for (Statement st : np.getAssertion()) {
                 assertNotNull(st.getObject(), "no null objects in assertion");
             }
+        }
+    }
+
+    @Test
+    void createFromHandleSystem_addsPubinfoLabelFromReferentName() throws Exception {
+        String handle = "10.3535/ZJX-6N5-A5C";
+        String body = "{\"responseCode\":1,\"handle\":\"" + handle + "\",\"values\":["
+                + "{\"index\":1,\"type\":\"fdoProfile\",\"data\":{\"format\":\"string\",\"value\":\"https://doi.org/21.T11148/profile\"}},"
+                + "{\"index\":2,\"type\":\"referentName\",\"data\":{\"format\":\"string\",\"value\":\"Rumex alpinus L.\"}}"
+                + "]}";
+
+        HttpResponse<String> resp = mock();
+        when(resp.body()).thenReturn(body);
+
+        try (MockedStatic<HttpClient> httpStatic = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString()))).thenReturn(resp);
+            httpStatic.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            Nanopub np = FdoNanopubCreator.createFromHandleSystem(handle);
+
+            IRI fdoIri = FdoUtils.createIri(handle);
+            boolean hasReferentLabel = np.getPubinfo().stream().anyMatch(st ->
+                    st.getSubject().equals(fdoIri)
+                    && st.getPredicate().equals(RDFS.LABEL)
+                    && st.getObject().stringValue().equals("Rumex alpinus L."));
+            assertTrue(hasReferentLabel, "pubinfo must carry rdfs:label from referentName");
+        }
+    }
+
+    @Test
+    void createFromHandleSystem_fallsBackToHandleIdAsLabel() throws Exception {
+        String handle = "10.3535/NO-REFERENT";
+        String body = "{\"responseCode\":1,\"handle\":\"" + handle + "\",\"values\":["
+                + "{\"index\":1,\"type\":\"fdoProfile\",\"data\":{\"format\":\"string\",\"value\":\"https://doi.org/21.T11148/profile\"}}"
+                + "]}";
+
+        HttpResponse<String> resp = mock();
+        when(resp.body()).thenReturn(body);
+
+        try (MockedStatic<HttpClient> httpStatic = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString()))).thenReturn(resp);
+            httpStatic.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            Nanopub np = FdoNanopubCreator.createFromHandleSystem(handle);
+
+            IRI fdoIri = FdoUtils.createIri(handle);
+            boolean hasHandleLabel = np.getPubinfo().stream().anyMatch(st ->
+                    st.getSubject().equals(fdoIri)
+                    && st.getPredicate().equals(RDFS.LABEL)
+                    && st.getObject().stringValue().equals(handle));
+            assertTrue(hasHandleLabel, "pubinfo must fall back to the handle id as rdfs:label");
+        }
+    }
+
+    @Test
+    void createFromHandleSystem_withEnrichment_rewritesPredicatesAndAddsLabels() throws Exception {
+        String handle = "20.5000.1025/J7E-C1H-1X2";
+        String profileHandleId = "21.T11148/2e76f544229901c5a942";
+
+        String fdoHandleResponse = "{\"responseCode\":1,\"handle\":\"20.5000.1025/J7E-C1H-1X2\",\"values\":["
+                + "{\"index\":1,\"type\":\"fdoProfile\",\"data\":{\"format\":\"string\",\"value\":\"https://doi.org/" + profileHandleId + "\"}},"
+                + "{\"index\":5,\"type\":\"digitalObjectName\",\"data\":{\"format\":\"string\",\"value\":\"Annotation\"}}"
+                + "]}";
+        String profileHandleResponse = "{\"responseCode\":1,\"handle\":\"" + profileHandleId + "\",\"values\":["
+                + "{\"index\":1,\"type\":\"10320/loc\",\"data\":{\"format\":\"string\",\"value\":"
+                + "\"<locations><location href=\\\"https://dtr.example.org/objects/" + profileHandleId + "\\\" view=\\\"json\\\" weight=\\\"1\\\"/></locations>\"}}"
+                + "]}";
+        String dtrBody = "{\"identifier\":\"" + profileHandleId + "\",\"properties\":["
+                + "{\"name\":\"fdoProfile\",\"identifier\":\"21.T11148/21e9228a604c7b37dfdf\"},"
+                + "{\"name\":\"digitalObjectName\",\"identifier\":\"21.T11148/4f2f5d61b57fb556aad9\"}"
+                + "]}";
+
+        HttpResponse<String> r1 = mock();
+        when(r1.body()).thenReturn(fdoHandleResponse);
+        HttpResponse<String> r2 = mock();
+        when(r2.body()).thenReturn(profileHandleResponse);
+        HttpResponse<String> r3 = mock();
+        when(r3.body()).thenReturn(dtrBody);
+
+        try (MockedStatic<HttpClient> httpStatic = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString())))
+                    .thenReturn(r1, r2, r3);
+            httpStatic.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            Nanopub np = FdoNanopubCreator.createFromHandleSystem(handle, true);
+
+            IRI fdoIri = FdoUtils.createIri(handle);
+            IRI profilePredicate = iri(HDL.NAMESPACE + "21.T11148/21e9228a604c7b37dfdf");
+            IRI namePredicate = iri(HDL.NAMESPACE + "21.T11148/4f2f5d61b57fb556aad9");
+            IRI fallbackNamePredicate = iri(FdoNanopubCreator.FDO_TYPE_PREFIX + "digitalObjectName");
+
+            boolean usesMappedName = np.getAssertion().stream().anyMatch(st ->
+                    st.getSubject().equals(fdoIri)
+                    && st.getPredicate().equals(namePredicate));
+            assertTrue(usesMappedName, "digitalObjectName must be rewritten to its handle IRI");
+
+            boolean fallbackAbsent = np.getAssertion().stream().noneMatch(st ->
+                    st.getPredicate().equals(fallbackNamePredicate));
+            assertTrue(fallbackAbsent, "fallback w3id kpxl predicate must not appear when mapping succeeded");
+
+            boolean hasNameLabel = np.getPubinfo().stream().anyMatch(st ->
+                    st.getSubject().equals(namePredicate)
+                    && st.getPredicate().equals(RDFS.LABEL)
+                    && st.getObject().stringValue().equals("digitalObjectName"));
+            assertTrue(hasNameLabel, "pubinfo must carry rdfs:label 'digitalObjectName' for its mapped predicate");
+
+            // fdoProfile's value was consumed by initFdoRecord (→ dct:conformsTo), so the mapped
+            // predicate is unused — but a label may still get added only if a value was processed.
+            // Ensure we didn't accidentally add a label for unused mappings.
+            boolean strayProfileLabel = np.getPubinfo().stream().anyMatch(st ->
+                    st.getSubject().equals(profilePredicate) && st.getPredicate().equals(RDFS.LABEL));
+            assertFalse(strayProfileLabel, "no pubinfo label for mappings that produced no assertion statement");
         }
     }
 

--- a/src/test/java/org/nanopub/fdo/FdoProfileSchemaLoaderTest.java
+++ b/src/test/java/org/nanopub/fdo/FdoProfileSchemaLoaderTest.java
@@ -1,0 +1,171 @@
+package org.nanopub.fdo;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.nanopub.fdo.rest.gson.Data;
+import org.nanopub.fdo.rest.gson.ParsedJsonResponse;
+import org.nanopub.fdo.rest.gson.Value;
+import org.nanopub.vocabulary.HDL;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpResponse;
+import java.util.Map;
+
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class FdoProfileSchemaLoaderTest {
+
+    @Test
+    void findJsonLocation_returnsJsonHrefFromLocationsXml() {
+        ParsedJsonResponse r = new ParsedJsonResponse();
+        Value v = new Value();
+        v.type = "10320/loc";
+        v.data = new Data();
+        v.data.value = "<locations>\n<location href=\"https://dtr.example.org/objects/21.T1/abc\" weight=\"1\" view=\"json\" />\n<location href=\"https://dtr.example.org/#objects/21.T1/abc\" weight=\"0\" view=\"ui\" />\n</locations>";
+        r.values = new Value[]{v};
+
+        assertEquals("https://dtr.example.org/objects/21.T1/abc", FdoProfileSchemaLoader.findJsonLocation(r));
+    }
+
+    @Test
+    void findJsonLocation_handlesUppercaseView() {
+        ParsedJsonResponse r = new ParsedJsonResponse();
+        Value v = new Value();
+        v.type = "10320/loc";
+        v.data = new Data();
+        v.data.value = "<locations><location href=\"https://dtr.example.org/x\" id=\"0\" view=\"JSON\" weight=\"1\"/></locations>";
+        r.values = new Value[]{v};
+
+        assertEquals("https://dtr.example.org/x", FdoProfileSchemaLoader.findJsonLocation(r));
+    }
+
+    @Test
+    void parsePropertyMap_dtrStyleProperties() {
+        String json = "{\"identifier\":\"21.T11148/profile\",\"name\":\"X\",\"properties\":["
+                + "{\"name\":\"fdoProfile\",\"identifier\":\"21.T11148/21e9228a604c7b37dfdf\"},"
+                + "{\"name\":\"digitalObjectName\",\"identifier\":\"21.T11148/4f2f5d61b57fb556aad9\"}"
+                + "]}";
+
+        Map<String, IRI> map = FdoProfileSchemaLoader.parsePropertyMap(json);
+
+        assertEquals(iri(HDL.NAMESPACE + "21.T11148/21e9228a604c7b37dfdf"), map.get("fdoProfile"));
+        assertEquals(iri(HDL.NAMESPACE + "21.T11148/4f2f5d61b57fb556aad9"), map.get("digitalObjectName"));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void parsePropertyMap_gwdgStyleSchemaProperties() {
+        String json = "{\"Identifier\":\"21.T11966/profile\",\"Schema\":{\"Properties\":["
+                + "{\"Name\":\"21.T11966/FdoProfile\",\"Type\":\"21.T11966/FdoProfile\"},"
+                + "{\"Name\":\"21.T11966/b5b58656b1fa5aff0505\",\"Type\":\"21.T11966/b5b58656b1fa5aff0505\"}"
+                + "]}}";
+
+        Map<String, IRI> map = FdoProfileSchemaLoader.parsePropertyMap(json);
+
+        assertEquals(iri(HDL.NAMESPACE + "21.T11966/FdoProfile"), map.get("21.T11966/FdoProfile"));
+        assertEquals(iri(HDL.NAMESPACE + "21.T11966/b5b58656b1fa5aff0505"), map.get("21.T11966/b5b58656b1fa5aff0505"));
+        assertEquals(2, map.size());
+    }
+
+    @Test
+    void parsePropertyMap_jsonSchemaObjectShape() {
+        String json = "{\"$schema\":\"http://json-schema.org/draft-04/schema#\",\"properties\":{"
+                + "\"21.T11966/1639bb8709dda583d357\":{\"@id\":\"hdl:21.T11966/1639bb8709dda583d357\",\"title\":\"DataRefs\",\"type\":\"array\"},"
+                + "\"21.T11966/FdoProfile\":{\"@id\":\"hdl:21.T11966/FdoProfile\",\"type\":\"string\"}"
+                + "}}";
+
+        Map<String, IRI> map = FdoProfileSchemaLoader.parsePropertyMap(json);
+
+        IRI dataRefsIri = iri(HDL.NAMESPACE + "21.T11966/1639bb8709dda583d357");
+        assertEquals(dataRefsIri, map.get("21.T11966/1639bb8709dda583d357"));
+        assertEquals(dataRefsIri, map.get("DataRefs"));
+        assertEquals(iri(HDL.NAMESPACE + "21.T11966/FdoProfile"), map.get("21.T11966/FdoProfile"));
+    }
+
+    @Test
+    void parsePropertyMap_titlesIndexedAsAlternateKeys() {
+        // GWDG-style with Title
+        String gwdg = "{\"Schema\":{\"Properties\":["
+                + "{\"Name\":\"21.T11966/1639bb8709dda583d357\",\"Title\":\"DataRefs\"}"
+                + "]}}";
+        Map<String, IRI> m1 = FdoProfileSchemaLoader.parsePropertyMap(gwdg);
+        IRI dataRefs = iri(HDL.NAMESPACE + "21.T11966/1639bb8709dda583d357");
+        assertEquals(dataRefs, m1.get("21.T11966/1639bb8709dda583d357"));
+        assertEquals(dataRefs, m1.get("DataRefs"));
+
+        // DTR array-style without title → only name key
+        String dissco = "{\"properties\":[{\"name\":\"fdoProfile\",\"identifier\":\"21.T11148/abc\"}]}";
+        Map<String, IRI> m2 = FdoProfileSchemaLoader.parsePropertyMap(dissco);
+        assertEquals(1, m2.size());
+    }
+
+    @Test
+    void parsePropertyMap_emptyOnUnknownShape() {
+        assertTrue(FdoProfileSchemaLoader.parsePropertyMap("{\"foo\":\"bar\"}").isEmpty());
+        assertTrue(FdoProfileSchemaLoader.parsePropertyMap("[]").isEmpty());
+    }
+
+    @Test
+    void parsePropertyMap_skipsEntriesWithNonHandleIdentifiers() {
+        String json = "{\"properties\":["
+                + "{\"name\":\"ok\",\"identifier\":\"21.T11148/valid\"},"
+                + "{\"name\":\"bad\",\"identifier\":\"not-a-handle\"}"
+                + "]}";
+
+        Map<String, IRI> map = FdoProfileSchemaLoader.parsePropertyMap(json);
+
+        assertTrue(map.containsKey("ok"));
+        assertFalse(map.containsKey("bad"));
+    }
+
+    @Test
+    void loadPropertyMap_returnsEmptyOnResolutionFailure() throws Exception {
+        HttpResponse<String> badResponse = mock();
+        when(badResponse.body()).thenReturn("not json");
+
+        try (MockedStatic<HttpClient> httpStatic = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString())))
+                    .thenReturn(badResponse);
+            httpStatic.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            Map<String, IRI> map = FdoProfileSchemaLoader.loadPropertyMap(
+                    iri("https://hdl.handle.net/21.T11148/profile"));
+
+            assertTrue(map.isEmpty());
+        }
+    }
+
+    @Test
+    void loadPropertyMap_resolvesViaHandleSystemAndDtr() throws Exception {
+        String handleResponseBody = "{\"responseCode\":1,\"handle\":\"21.T11148/profile\",\"values\":["
+                + "{\"index\":1,\"type\":\"10320/loc\",\"data\":{\"format\":\"string\",\"value\":"
+                + "\"<locations><location href=\\\"https://dtr.example.org/objects/21.T11148/profile\\\" view=\\\"json\\\" weight=\\\"1\\\"/></locations>\"}}"
+                + "]}";
+        String dtrBody = "{\"properties\":[{\"name\":\"fdoProfile\",\"identifier\":\"21.T11148/abc\"}]}";
+
+        HttpResponse<String> handleResp = mock();
+        when(handleResp.body()).thenReturn(handleResponseBody);
+        HttpResponse<String> dtrResp = mock();
+        when(dtrResp.body()).thenReturn(dtrBody);
+
+        try (MockedStatic<HttpClient> httpStatic = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString())))
+                    .thenReturn(handleResp)
+                    .thenReturn(dtrResp);
+            httpStatic.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            Map<String, IRI> map = FdoProfileSchemaLoader.loadPropertyMap(
+                    iri("https://doi.org/21.T11148/profile"));
+
+            assertEquals(iri(HDL.NAMESPACE + "21.T11148/abc"), map.get("fdoProfile"));
+            assertEquals(1, map.size());
+        }
+    }
+
+}

--- a/src/test/java/org/nanopub/fdo/FdoUtilsTest.java
+++ b/src/test/java/org/nanopub/fdo/FdoUtilsTest.java
@@ -96,6 +96,18 @@ class FdoUtilsTest {
     }
 
     @Test
+    void extractHandleId_stripsKnownPrefixes() {
+        assertEquals("10.3535/ZJX-6N5-A5C", FdoUtils.extractHandleId("https://hdl.handle.net/10.3535/ZJX-6N5-A5C"));
+        assertEquals("10.3535/ZJX-6N5-A5C", FdoUtils.extractHandleId("http://hdl.handle.net/10.3535/ZJX-6N5-A5C"));
+        assertEquals("21.T11148/abc", FdoUtils.extractHandleId("https://doi.org/21.T11148/abc"));
+        assertEquals("21.T11148/abc", FdoUtils.extractHandleId("http://doi.org/21.T11148/abc"));
+        assertEquals("21.T11148/abc", FdoUtils.extractHandleId("21.T11148/abc"));
+        assertNull(FdoUtils.extractHandleId("not a handle"));
+        assertNull(FdoUtils.extractHandleId("https://example.org/something"));
+        assertNull(FdoUtils.extractHandleId(null));
+    }
+
+    @Test
     void toIriWithHandle() {
         String handle = VALID_HANDLE;
         IRI result = FdoUtils.toIri(handle);


### PR DESCRIPTION
Follow-up to #70.

## Summary
- **`-s` / `--enrich-from-schema`** (opt-in): resolves the FDO profile via the handle system, fetches its Data Type Registry entry, and rewrites field names into handle IRIs as predicates. Each mapped predicate gets an `rdfs:label` (the original field name) in pubinfo. Falls back gracefully when the profile schema can't be resolved.
- Three DTR shapes are recognised: DiSSCo (`properties[{name,identifier}]`), JSON Schema object (`properties: {<handle>: {title}}`), and GWDG (`Schema.Properties[{Name,Title?}]`). `title`/`Title` are indexed as alternate lookup keys.
- **Handle / DOI URLs** are accepted by the CLI: `np fdo https://hdl.handle.net/10.3535/ZJX-6N5-A5C` and `np fdo https://doi.org/10.3535/ZJX-6N5-A5C` both work, in addition to the bare handle. New shared helper `FdoUtils.extractHandleId(String)`.
- **`<fdoIri> rdfs:label "..."` in pubinfo**, sourced from `referentName` when present, falling back to the bare handle id otherwise.

## Examples
```
$ np fdo -u https://hdl.handle.net/10.3535/ZJX-6N5-A5C
... (pubinfo) ...
<https://hdl.handle.net/10.3535/ZJX-6N5-A5C> rdfs:label "Rumex alpinus L." .

$ np fdo -u -s 20.5000.1025/J7E-C1H-1X2
... predicates rewritten to hdl:21.T11148/... handle IRIs ...
... pubinfo carries rdfs:label for each mapped predicate ...
```

## Known limitation
For profiles whose DTR entry only carries handle keys (no `name` or `Title` matching the record fields), `-s` produces no rewrites. Example: `21.T11967/39b0ec87d17a4856c5f7` uses Cordra-local field names like `DataRef`/`MetadataRef`, while its profile has `Title="DataRefs"`/`"MetadataRefs"` — singular/plural mismatch. No heuristic stripper is shipped.

## Test plan
- [x] `mvn test -Dtest='FdoNanopubCreatorTest,FdoProfileSchemaLoaderTest,FdoUtilsTest'` — 40 tests pass.
- [x] New tests cover: all three DTR shapes; title-as-alternate-key indexing; HTTP failure modes; end-to-end enrichment that rewrites predicates and emits labels only for mappings that produced statements; URL prefix stripping for hdl.handle.net and doi.org; referentName → pubinfo label; handle-id fallback when no referentName.
- [x] Live smoke tests: DiSSCo handle (URL form, with `-s`), GWDG/Cordra handle (limitation confirmed), invalid URL (clear error message before any network call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)