### PR TITLE
Attach FDO label to nanopub; preserve DOI URL as FDO IRI

### DIFF
--- a/src/main/java/org/nanopub/fdo/FdoCreate.java
+++ b/src/main/java/org/nanopub/fdo/FdoCreate.java
@@ -71,13 +71,12 @@ public class FdoCreate extends CliRunner {
             throw new ParameterException("Cannot use -u and -p together.");
         }
 
-        String resolvedId = FdoUtils.extractHandleId(handleId);
-        if (resolvedId == null) {
+        if (FdoUtils.extractHandleId(handleId) == null) {
             System.err.println("Not a recognisable handle or handle/DOI URL: " + handleId);
             throw new ParameterException("Not a recognisable handle or handle/DOI URL: " + handleId);
         }
 
-        Nanopub np = FdoNanopubCreator.createFromHandleSystem(resolvedId, enrichFromSchema);
+        Nanopub np = FdoNanopubCreator.createFromHandleSystem(handleId, enrichFromSchema);
 
         if (unsigned) {
             NanopubUtils.writeToStream(np, System.out, RDFFormat.TRIG);

--- a/src/main/java/org/nanopub/fdo/FdoNanopubCreator.java
+++ b/src/main/java/org/nanopub/fdo/FdoNanopubCreator.java
@@ -120,17 +120,21 @@ public class FdoNanopubCreator {
      * @throws org.nanopub.NanopubAlreadyFinalizedException if the Nanopub has already been finalized
      */
     public static Nanopub createFromHandleSystem(String id, boolean enrichFromSchema) throws MalformedNanopubException, URISyntaxException, IOException, InterruptedException, NanopubAlreadyFinalizedException {
-        ParsedJsonResponse response = new HandleResolver().call(id);
+        String handleId = FdoUtils.extractHandleId(id);
+        if (handleId == null) {
+            throw new MalformedNanopubException("Not a recognisable handle or handle/DOI URL: " + id);
+        }
+        ParsedJsonResponse response = new HandleResolver().call(handleId);
         Map<IRI, String> labelSink = new LinkedHashMap<>();
-        FdoRecord record = buildFdoRecord(id, response, enrichFromSchema, labelSink);
+        FdoRecord record = buildFdoRecord(handleId, response, enrichFromSchema, labelSink);
 
         IRI fdoIri = FdoUtils.createIri(id);
         NanopubCreator creator = createWithFdoIri(record, fdoIri);
-        creator.addProvenanceStatement(PROV.WAS_DERIVED_FROM, vf.createIRI(HandleResolver.BASE_URI + id));
+        creator.addProvenanceStatement(PROV.WAS_DERIVED_FROM, vf.createIRI(HandleResolver.BASE_URI + handleId));
         for (Map.Entry<IRI, String> e : labelSink.entrySet()) {
             creator.addPubinfoStatement(e.getKey(), RDFS.LABEL, vf.createLiteral(e.getValue()));
         }
-        creator.addPubinfoStatement(fdoIri, RDFS.LABEL, vf.createLiteral(resolveFdoLabel(response, id)));
+        creator.addPubinfoStatement(RDFS.LABEL, vf.createLiteral(resolveFdoLabel(response, handleId)));
         return creator.finalizeNanopub(true);
     }
 
@@ -174,8 +178,12 @@ public class FdoNanopubCreator {
      * @throws org.nanopub.MalformedNanopubException  if the handle record has no recognised profile type
      */
     public static FdoRecord createFdoRecordFromHandleSystem(String id, boolean enrichFromSchema, Map<IRI, String> labelSink) throws URISyntaxException, IOException, InterruptedException, MalformedNanopubException {
-        ParsedJsonResponse response = new HandleResolver().call(id);
-        return buildFdoRecord(id, response, enrichFromSchema, labelSink);
+        String handleId = FdoUtils.extractHandleId(id);
+        if (handleId == null) {
+            throw new MalformedNanopubException("Not a recognisable handle or handle/DOI URL: " + id);
+        }
+        ParsedJsonResponse response = new HandleResolver().call(handleId);
+        return buildFdoRecord(handleId, response, enrichFromSchema, labelSink);
     }
 
     private static FdoRecord buildFdoRecord(String id, ParsedJsonResponse response, boolean enrichFromSchema, Map<IRI, String> labelSink) throws MalformedNanopubException {

--- a/src/test/java/org/nanopub/fdo/FdoNanopubCreatorTest.java
+++ b/src/test/java/org/nanopub/fdo/FdoNanopubCreatorTest.java
@@ -332,12 +332,11 @@ public class FdoNanopubCreatorTest {
 
             Nanopub np = FdoNanopubCreator.createFromHandleSystem(handle);
 
-            IRI fdoIri = FdoUtils.createIri(handle);
             boolean hasReferentLabel = np.getPubinfo().stream().anyMatch(st ->
-                    st.getSubject().equals(fdoIri)
+                    st.getSubject().equals(np.getUri())
                     && st.getPredicate().equals(RDFS.LABEL)
                     && st.getObject().stringValue().equals("Rumex alpinus L."));
-            assertTrue(hasReferentLabel, "pubinfo must carry rdfs:label from referentName");
+            assertTrue(hasReferentLabel, "pubinfo must carry rdfs:label from referentName on the nanopub");
         }
     }
 
@@ -358,12 +357,54 @@ public class FdoNanopubCreatorTest {
 
             Nanopub np = FdoNanopubCreator.createFromHandleSystem(handle);
 
-            IRI fdoIri = FdoUtils.createIri(handle);
             boolean hasHandleLabel = np.getPubinfo().stream().anyMatch(st ->
-                    st.getSubject().equals(fdoIri)
+                    st.getSubject().equals(np.getUri())
                     && st.getPredicate().equals(RDFS.LABEL)
                     && st.getObject().stringValue().equals(handle));
-            assertTrue(hasHandleLabel, "pubinfo must fall back to the handle id as rdfs:label");
+            assertTrue(hasHandleLabel, "pubinfo must fall back to the handle id as rdfs:label on the nanopub");
+        }
+    }
+
+    @Test
+    void createFromHandleSystem_withDoiUrl_preservesDoiIri() throws Exception {
+        String handle = "10.3535/DOI-TEST";
+        String doiUrl = "https://doi.org/" + handle;
+        String body = "{\"responseCode\":1,\"handle\":\"" + handle + "\",\"values\":["
+                + "{\"index\":1,\"type\":\"fdoProfile\",\"data\":{\"format\":\"string\",\"value\":\"https://doi.org/21.T11148/profile\"}},"
+                + "{\"index\":2,\"type\":\"referentName\",\"data\":{\"format\":\"string\",\"value\":\"DOI Thing\"}}"
+                + "]}";
+
+        HttpResponse<String> resp = mock();
+        when(resp.body()).thenReturn(body);
+
+        try (MockedStatic<HttpClient> httpStatic = mockStatic(HttpClient.class)) {
+            HttpClient mockClient = mock();
+            when(mockClient.send(Mockito.any(), eq(HttpResponse.BodyHandlers.ofString()))).thenReturn(resp);
+            httpStatic.when(HttpClient::newHttpClient).thenReturn(mockClient);
+
+            Nanopub np = FdoNanopubCreator.createFromHandleSystem(doiUrl);
+
+            IRI fdoIri = iri(doiUrl);
+            boolean introducesDoiIri = np.getPubinfo().stream().anyMatch(st ->
+                    st.getPredicate().equals(NPX.INTRODUCES)
+                    && st.getObject().equals(fdoIri));
+            assertTrue(introducesDoiIri, "pubinfo must introduce the DOI URL as the FDO IRI");
+
+            boolean typedAsFdo = np.getAssertion().stream().anyMatch(st ->
+                    st.getSubject().equals(fdoIri)
+                    && st.getPredicate().equals(RDF.TYPE)
+                    && st.getObject().equals(FDOF.FAIR_DIGITAL_OBJECT));
+            assertTrue(typedAsFdo, "assertion must type the DOI URL as fdof:FAIRDigitalObject");
+
+            boolean noHdlSubject = np.getAssertion().stream().noneMatch(st ->
+                    st.getSubject().stringValue().startsWith(HDL.NAMESPACE + handle));
+            assertTrue(noHdlSubject, "DOI URL must not be rewritten to hdl.handle.net in assertion");
+
+            IRI derivedFrom = iri(HandleResolver.BASE_URI + handle);
+            boolean hasDerivedFrom = np.getProvenance().stream().anyMatch(st ->
+                    st.getPredicate().equals(PROV.WAS_DERIVED_FROM)
+                    && st.getObject().equals(derivedFrom));
+            assertTrue(hasDerivedFrom, "provenance still points at the handle API URL");
         }
     }
 


### PR DESCRIPTION
## Summary
- `rdfs:label` derived from `referentName` (and its handle-id fallback) is now attached to the nanopub itself in pubinfo, not to the introduced FDO resource.
- When the input to `FdoCreate` / `FdoNanopubCreator.createFromHandleSystem` is a DOI URL (e.g. `https://doi.org/10.3535/XYZ`), the FDO IRI stays as that DOI URL instead of being rewritten to `https://hdl.handle.net/...`. Handle API resolution and provenance (`prov:wasDerivedFrom`) still use the bare handle id.

## Test plan
- [x] `mvn test -Dtest=FdoNanopubCreatorTest,FdoUtilsTest,FdoCreateTest` — all pass, including the new `createFromHandleSystem_withDoiUrl_preservesDoiIri` case.
- [x] Manual CLI check: `FdoCreate https://doi.org/10.3535/ZJX-6N5-A5C` produces a nanopub whose FDO IRI is the DOI URL and whose pubinfo `rdfs:label` sits on `this:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)