### PR TITLE
Safe dependency bumps (rdf4j, guava, jelly-rdf4j, jakarta.xml.bind-api, snakeyaml)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>jakarta.xml.bind</groupId>
       <artifactId>jakarta.xml.bind-api</artifactId>
-      <version>4.0.2</version>
+      <version>4.0.5</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>2.5</version>
+      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <rdf4j.version>5.1.5</rdf4j.version>
+    <rdf4j.version>5.3.0</rdf4j.version>
     <slf4j.version>2.0.17</slf4j.version>
   </properties>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.4.8-jre</version>
+      <version>33.6.0-jre</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>eu.neverblink.jelly</groupId>
       <artifactId>jelly-rdf4j</artifactId>
-      <version>3.5.2</version>
+      <version>3.7.2</version>
     </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>


### PR DESCRIPTION
## Summary
Applies the patch / minor-level bumps that `mvn versions:display-dependency-updates` flagged. Each commit is a single dependency bump so anything that regresses can be reverted individually.

- rdf4j 5.1.5 → 5.3.0 (all six rdf4j-* artifacts via the `rdf4j.version` property)
- guava 33.4.8-jre → 33.6.0-jre
- jelly-rdf4j 3.5.2 → 3.7.2
- jakarta.xml.bind-api 4.0.2 → 4.0.5
- snakeyaml 2.5 → 2.6

Pre-release updates (`jakarta.activation-api 2.2.0-M2`, `junit-jupiter 6.1.0-M1`, `slf4j 2.1.0-alpha1`) were intentionally skipped. `httpclient` is still on 4.5.14; moving to httpclient5 is a migration, not a version bump, and is out of scope here.

## Test plan
- [x] `mvn test` passes after every commit (499/499 tests green)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)