### PR TITLE
feat(services): discover query API instances from nanopub setting

### DIFF
--- a/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
@@ -34,7 +34,7 @@ public class NanopubServerUtils {
     public static List<String> getBootstrapServerList() {
         if (bootstrapServerList.isEmpty()) {
             try {
-                for (IRI iri : NanopubSetting.getLocalSetting().getBootstrapServices()) {
+                for (IRI iri : NanopubSetting.getDefaultSetting().getBootstrapServices()) {
                     bootstrapServerList.add(iri.stringValue());
                 }
             } catch (RDF4JException | MalformedNanopubException | IOException ex) {

--- a/src/main/java/org/nanopub/extra/services/QueryCall.java
+++ b/src/main/java/org/nanopub/extra/services/QueryCall.java
@@ -4,6 +4,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
 import org.nanopub.NanopubUtils;
+import org.nanopub.vocabulary.NPS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,26 +51,41 @@ public class QueryCall {
     }
 
     /**
-     * List of available query API instances.
+     * System property naming a whitespace-separated list of query API instance URLs.
+     * When set, this overrides discovery via the nanopub setting (env var
+     * {@code NANOPUB_QUERY_INSTANCES} also accepted).
      */
-    // TODO Available services should be retrieved from a setting, not hard-coded:
-    public static String[] queryApiInstances = new String[]{
-            "https://query.knowledgepixels.com/",
-            "https://query.petapico.org/",
-            "https://query.nanodash.net/"
-    };
+    public static final String QUERY_INSTANCES_PROPERTY = "nanopub.query.instances";
+
+    /**
+     * Environment variable equivalent of {@link #QUERY_INSTANCES_PROPERTY}.
+     */
+    public static final String QUERY_INSTANCES_ENV = "NANOPUB_QUERY_INSTANCES";
 
     private static List<String> checkedApiInstances;
 
     /**
      * Returns the list of available query API instances that are currently accessible.
+     * <p>
+     * Sources, in order of priority:
+     * <ol>
+     *   <li>{@code nanopub.query.instances} system property / {@code NANOPUB_QUERY_INSTANCES} env var
+     *       (whitespace-separated URLs).</li>
+     *   <li>The active {@link org.nanopub.extra.setting.NanopubSetting}'s service intro collection,
+     *       filtered to services of type {@link NPS#NANOPUB_QUERY_1_1}.</li>
+     * </ol>
+     * Each candidate is liveness-checked via an HTTP GET to its root URL.
      *
-     * @return a list of accessible query API instance
+     * @return a list of accessible query API instances
      */
     public static List<String> getApiInstances() throws NotEnoughAPIInstancesException {
         if (checkedApiInstances != null) return checkedApiInstances;
+        List<String> candidates = resolveCandidateInstances();
+        if (candidates.isEmpty()) {
+            throw new NotEnoughAPIInstancesException("No query API instances configured or discoverable");
+        }
         checkedApiInstances = new ArrayList<>();
-        for (String a : queryApiInstances) {
+        for (String a : candidates) {
             try {
                 logger.info("Checking API instance: {}", a);
                 HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(a));
@@ -90,6 +106,20 @@ public class QueryCall {
             throw new NotEnoughAPIInstancesException("Not enough healthy Nanopub Query instances available");
         }
         return checkedApiInstances;
+    }
+
+    private static List<String> resolveCandidateInstances() {
+        String override = System.getProperty(QUERY_INSTANCES_PROPERTY);
+        if (override == null || override.isEmpty()) override = System.getenv(QUERY_INSTANCES_ENV);
+        if (override != null && !override.trim().isEmpty()) {
+            List<String> list = new ArrayList<>();
+            for (String url : override.trim().split("\\s+")) list.add(url);
+            logger.info("Using {} query API instance(s) from override", list.size());
+            return list;
+        }
+        List<String> fromSetting = ServiceLookup.getServices(NPS.NANOPUB_QUERY_1_1);
+        logger.info("Discovered {} query API instance(s) from setting", fromSetting.size());
+        return new ArrayList<>(fromSetting);
     }
 
     private QueryRef queryRef;

--- a/src/main/java/org/nanopub/extra/services/ServiceLookup.java
+++ b/src/main/java/org/nanopub/extra/services/ServiceLookup.java
@@ -1,0 +1,113 @@
+package org.nanopub.extra.services;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.nanopub.MalformedNanopubException;
+import org.nanopub.Nanopub;
+import org.nanopub.extra.index.IndexUtils;
+import org.nanopub.extra.index.NanopubIndex;
+import org.nanopub.extra.server.GetNanopub;
+import org.nanopub.extra.setting.NanopubSetting;
+import org.nanopub.vocabulary.NPX;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves nanopub service URLs of a given type from the active {@link NanopubSetting}.
+ * <p>
+ * The setting points to a service intro collection (a {@link NanopubIndex}) whose elements
+ * are individual service intro nanopubs. Each service intro asserts
+ * {@code <service-url> a npx:NanopubService, <service-type-iri>}.
+ */
+public class ServiceLookup {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServiceLookup.class);
+
+    private static final Map<IRI, List<String>> cache = new HashMap<>();
+
+    private ServiceLookup() {
+    }
+
+    /**
+     * Returns the URLs of all services of the given type listed in the active setting's
+     * service intro collection. Cached for the JVM lifetime.
+     *
+     * @param typeIri the service type IRI (e.g. {@code NPS.NANOPUB_QUERY_1_1})
+     * @return service URLs (may be empty if nothing matched or lookup failed)
+     */
+    public static synchronized List<String> getServices(IRI typeIri) {
+        List<String> cached = cache.get(typeIri);
+        if (cached != null) return cached;
+        List<String> urls = new ArrayList<>();
+        try {
+            NanopubSetting setting = NanopubSetting.getDefaultSetting();
+            IRI collectionIri = setting.getServiceIntroCollection();
+            if (collectionIri == null) {
+                logger.warn("No service intro collection in setting; cannot look up services of type {}", typeIri);
+                cache.put(typeIri, urls);
+                return urls;
+            }
+            Nanopub collectionNp = GetNanopub.get(collectionIri.stringValue());
+            if (collectionNp == null) {
+                logger.error("Could not retrieve service intro collection: {}", collectionIri);
+                cache.put(typeIri, urls);
+                return urls;
+            }
+            NanopubIndex index = IndexUtils.castToIndex(collectionNp);
+            for (IRI elementIri : index.getElements()) {
+                try {
+                    Nanopub introNp = GetNanopub.get(elementIri.stringValue());
+                    if (introNp == null) {
+                        logger.warn("Could not retrieve service intro nanopub: {}", elementIri);
+                        continue;
+                    }
+                    String url = extractServiceUrl(introNp, typeIri);
+                    if (url != null) urls.add(url);
+                } catch (Exception ex) {
+                    logger.warn("Failed to process service intro {}: {}", elementIri, ex.getMessage());
+                }
+            }
+        } catch (Exception ex) {
+            logger.error("Failed to look up services of type {}", typeIri, ex);
+        }
+        cache.put(typeIri, urls);
+        return urls;
+    }
+
+    /**
+     * Clears the lookup cache. Intended for tests.
+     */
+    public static synchronized void clearCache() {
+        cache.clear();
+    }
+
+    private static String extractServiceUrl(Nanopub introNp, IRI typeIri) throws MalformedNanopubException {
+        IRI subject = null;
+        boolean hasNanopubServiceType = false;
+        boolean hasRequestedType = false;
+        for (Statement st : introNp.getAssertion()) {
+            if (!st.getPredicate().equals(RDF.TYPE)) continue;
+            if (!(st.getSubject() instanceof IRI subj)) continue;
+            if (!(st.getObject() instanceof IRI obj)) continue;
+            if (subject == null) {
+                subject = subj;
+            } else if (!subject.equals(subj)) {
+                throw new MalformedNanopubException(
+                        "Service intro " + introNp.getUri() + " has multiple typed subjects");
+            }
+            if (obj.equals(NPX.NANOPUB_SERVICE)) hasNanopubServiceType = true;
+            if (obj.equals(typeIri)) hasRequestedType = true;
+        }
+        if (subject != null && hasNanopubServiceType && hasRequestedType) {
+            return subject.stringValue();
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/org/nanopub/extra/setting/NanopubSetting.java
+++ b/src/main/java/org/nanopub/extra/setting/NanopubSetting.java
@@ -13,6 +13,7 @@ import org.nanopub.Nanopub;
 import org.nanopub.NanopubImpl;
 import org.nanopub.vocabulary.NPX;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -26,6 +27,44 @@ import java.util.Set;
 public class NanopubSetting implements Serializable {
 
     private static ValueFactory vf = SimpleValueFactory.getInstance();
+
+    /**
+     * System property naming a TriG file with a custom setting nanopub. Overrides the
+     * bundled default setting when set (env var {@code NANOPUB_SETTING_FILE} also accepted).
+     */
+    public static final String SETTING_FILE_PROPERTY = "nanopub.setting.file";
+
+    /**
+     * Environment variable equivalent of {@link #SETTING_FILE_PROPERTY}.
+     */
+    public static final String SETTING_FILE_ENV = "NANOPUB_SETTING_FILE";
+
+    private static volatile NanopubSetting defaultSetting;
+
+    /**
+     * Retrieves the default nanopub setting, honoring the {@code nanopub.setting.file}
+     * system property and the {@code NANOPUB_SETTING_FILE} environment variable as
+     * overrides. When neither is set, falls back to {@link #getLocalSetting()}.
+     *
+     * @return the default NanopubSetting object
+     * @throws org.eclipse.rdf4j.common.exception.RDF4JException if there is an error with RDF4J operations.
+     * @throws org.nanopub.MalformedNanopubException             if the nanopub is malformed.
+     * @throws java.io.IOException                               if there is an error reading the input stream.
+     */
+    public static NanopubSetting getDefaultSetting() throws RDF4JException, MalformedNanopubException, IOException {
+        if (defaultSetting != null) return defaultSetting;
+        synchronized (NanopubSetting.class) {
+            if (defaultSetting != null) return defaultSetting;
+            String path = System.getProperty(SETTING_FILE_PROPERTY);
+            if (path == null || path.isEmpty()) path = System.getenv(SETTING_FILE_ENV);
+            if (path != null && !path.isEmpty()) {
+                defaultSetting = new NanopubSetting(new NanopubImpl(new File(path)));
+            } else {
+                defaultSetting = getLocalSetting();
+            }
+            return defaultSetting;
+        }
+    }
 
     /**
      * Retrieves the default local nanopub setting.

--- a/src/main/java/org/nanopub/vocabulary/NPS.java
+++ b/src/main/java/org/nanopub/vocabulary/NPS.java
@@ -1,0 +1,21 @@
+package org.nanopub.vocabulary;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+
+/**
+ * Service-type IRIs used in service intro nanopubs (the secondary type next to {@code npx:NanopubService}).
+ */
+public class NPS {
+
+    public static final String NAMESPACE = "https://w3id.org/np/o/service/terms/";
+
+    public static final String PREFIX = "nps";
+
+    public static final Namespace NS = VocabUtils.createNamespace(PREFIX, NAMESPACE);
+
+    public static final IRI NANOPUB_QUERY_1_1 = VocabUtils.createIRI(NAMESPACE, "nanopub-query-1.1");
+    public static final IRI NANOPUB_REGISTRY_1_0 = VocabUtils.createIRI(NAMESPACE, "nanopub-registry-1.0");
+    public static final IRI NANODASH_2_X = VocabUtils.createIRI(NAMESPACE, "nanodash-2.x");
+
+}

--- a/src/test/java/org/nanopub/extra/services/QueryCallTest.java
+++ b/src/test/java/org/nanopub/extra/services/QueryCallTest.java
@@ -5,7 +5,6 @@ import org.nanopub.utils.MockNanopubUtils;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -14,34 +13,44 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class QueryCallTest {
 
     private MockNanopubUtils mockNanopubUtils;
-    private static String[] queryApiInstancesOld;
+    private static String overridePropertyOld;
+
+    private static final String DEFAULT_INSTANCES =
+            "https://query.knowledgepixels.com/ https://query.petapico.org/ https://query.nanodash.net/";
 
     @BeforeAll
     static void beforeAll() {
-        // Store the original queryApiInstances for later restoration
-        queryApiInstancesOld = QueryCall.queryApiInstances;
+        overridePropertyOld = System.getProperty(QueryCall.QUERY_INSTANCES_PROPERTY);
     }
 
     @BeforeEach
-    void setUp() throws IOException {
+    void setUp() throws IOException, NoSuchFieldException, IllegalAccessException {
+        resetCheckedApiInstances();
+        ServiceLookup.clearCache();
         mockNanopubUtils = new MockNanopubUtils();
+        System.setProperty(QueryCall.QUERY_INSTANCES_PROPERTY, DEFAULT_INSTANCES);
     }
 
 
     @AfterEach
     void tearDown() throws NoSuchFieldException, IllegalAccessException {
-        // Reset the static field 'checkedApiInstances' to null after each test using reflection
+        resetCheckedApiInstances();
+        mockNanopubUtils.close();
+    }
+
+    private static void resetCheckedApiInstances() throws NoSuchFieldException, IllegalAccessException {
         Field field = QueryCall.class.getDeclaredField("checkedApiInstances");
         field.setAccessible(true);
         field.set(null, null);
-
-        mockNanopubUtils.close();
     }
 
     @AfterAll
     static void afterAll() {
-        // Restore the original queryApiInstances
-        QueryCall.queryApiInstances = queryApiInstancesOld;
+        if (overridePropertyOld == null) {
+            System.clearProperty(QueryCall.QUERY_INSTANCES_PROPERTY);
+        } else {
+            System.setProperty(QueryCall.QUERY_INSTANCES_PROPERTY, overridePropertyOld);
+        }
     }
 
     @Test
@@ -56,13 +65,13 @@ public class QueryCallTest {
         QueryCall.getApiInstances();
 
         // Call again to check if it uses the cached instances
-        assertEquals(Arrays.stream(QueryCall.queryApiInstances).toList(), QueryCall.getApiInstances());
+        assertEquals(List.of(DEFAULT_INSTANCES.split(" ")), QueryCall.getApiInstances());
     }
 
     @Test
     void getApiInstancesWithOnlyOneInstance() {
         mockNanopubUtils.setHttpResponseStatusCode(200);
-        QueryCall.queryApiInstances = new String[]{"https://mocked.instance1.com/"};
+        System.setProperty(QueryCall.QUERY_INSTANCES_PROPERTY, "https://mocked.instance1.com/");
         assertThrows(NotEnoughAPIInstancesException.class, QueryCall::getApiInstances);
     }
 
@@ -70,7 +79,7 @@ public class QueryCallTest {
     void getApiInstancesWithValidInstances() throws NotEnoughAPIInstancesException {
         mockNanopubUtils.setHttpResponseStatusCode(200);
         List<String> apiInstances = QueryCall.getApiInstances();
-        assertEquals(apiInstances, List.of(QueryCall.queryApiInstances));
+        assertEquals(apiInstances, List.of(DEFAULT_INSTANCES.split(" ")));
     }
 
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded list of Nanopub Query API instances in `QueryCall` with discovery via the active `NanopubSetting`. Service intro nanopubs of type `nanopub-query-1.1` (in the setting's service intro collection) contribute their URL.
- Adds two override layers (mirroring `nanopub-registry`'s pattern), both available to library users and CLI invocations:
  - `nanopub.query.instances` / `NANOPUB_QUERY_INSTANCES`: whitespace-separated URLs, bypassing the setting.
  - `nanopub.setting.file` / `NANOPUB_SETTING_FILE`: load `NanopubSetting` from a custom TriG file. Also used for bootstrap registries via `NanopubServerUtils`.
- Adds `org.nanopub.vocabulary.NPS` for service-type IRIs, `ServiceLookup` utility, and `NanopubSetting.getDefaultSetting()`.

Side effect: `query.knowledgepixels.com`, `query.petapico.org`, `query.nanodash.net` and `nanopub.sdsc.edu` are all currently registered as `nanopub-query-1.1` services, so the discovered list is now 4 entries (previously hardcoded 3). Unhealthy ones are filtered by the existing root-URL liveness check.

## Test plan

- [x] `mvn test` — all 499 tests pass
- [x] `QueryCallTest` rewritten to drive the new override path; reset static caches in both `@BeforeEach` and `@AfterEach` for robustness against suite ordering
- [x] Manual smoke test: run a CLI query without an override (uses setting-driven discovery) and with `-Dnanopub.query.instances=...` (uses override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)