### PR TITLE
feat(server): discover registry instances from nanopub setting

### DIFF
--- a/src/main/java/org/nanopub/extra/server/GetNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/GetNanopub.java
@@ -107,7 +107,25 @@ public class GetNanopub extends CliRunner {
      * @return the Nanopub object, or null if not found
      */
     public static Nanopub get(String uriOrArtifactCode, HttpClient httpClient) {
-        ServerIterator serverIterator = new ServerIterator();
+        return getWithIterator(uriOrArtifactCode, new ServerIterator(), httpClient);
+    }
+
+    /**
+     * Get a nanopub using an explicit seed list of registry URLs, bypassing the
+     * default registry-discovery path. The seed list is used directly by a
+     * fresh {@link ServerIterator}, which still crawls outward to find more
+     * registries. Intended for callers that need to break out of registry
+     * discovery (e.g. {@link org.nanopub.extra.services.ServiceLookup}).
+     *
+     * @param uriOrArtifactCode the URI or artifact code of the nanopub
+     * @param seedServers       the seed registry URLs
+     * @return the Nanopub object, or null if not found
+     */
+    public static Nanopub get(String uriOrArtifactCode, List<String> seedServers) {
+        return getWithIterator(uriOrArtifactCode, new ServerIterator(seedServers), NanopubUtils.getHttpClient());
+    }
+
+    private static Nanopub getWithIterator(String uriOrArtifactCode, ServerIterator serverIterator, HttpClient httpClient) {
         ArtifactCode ac = getArtifactCode(uriOrArtifactCode);
         if (!ac.getModule().getModuleId().equals(RdfModule.MODULE_ID)) {
             throw new IllegalArgumentException("Not a trusty URI of type " + RdfModule.MODULE_ID);

--- a/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
@@ -6,17 +6,36 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
+import org.nanopub.extra.services.ServiceLookup;
 import org.nanopub.extra.setting.NanopubSetting;
+import org.nanopub.vocabulary.NPS;
 import org.nanopub.vocabulary.NPX;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
  * Utility class for handling nanopub server-related operations.
  */
 public class NanopubServerUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(NanopubServerUtils.class);
+
+    /**
+     * System property naming a whitespace-separated list of registry server URLs.
+     * When set, this overrides discovery via the nanopub setting (env var
+     * {@code NANOPUB_REGISTRY_INSTANCES} also accepted).
+     */
+    public static final String REGISTRY_INSTANCES_PROPERTY = "nanopub.registry.instances";
+
+    /**
+     * Environment variable equivalent of {@link #REGISTRY_INSTANCES_PROPERTY}.
+     */
+    public static final String REGISTRY_INSTANCES_ENV = "NANOPUB_REGISTRY_INSTANCES";
 
     /**
      * Singleton, no instances.
@@ -25,6 +44,7 @@ public class NanopubServerUtils {
     }
 
     private static final List<String> bootstrapServerList = new ArrayList<>();
+    private static List<String> registryServerList;
 
     /**
      * Returns a list of bootstrap servers.
@@ -42,6 +62,43 @@ public class NanopubServerUtils {
             }
         }
         return bootstrapServerList;
+    }
+
+    /**
+     * Returns the list of registry server URLs to seed a {@link ServerIterator}.
+     * <p>
+     * Sources, in order of priority:
+     * <ol>
+     *   <li>{@code nanopub.registry.instances} system property /
+     *       {@code NANOPUB_REGISTRY_INSTANCES} env var (whitespace-separated URLs).
+     *       Replaces both bootstrap and discovery when set.</li>
+     *   <li>Otherwise: the union of the setting's bootstrap services and
+     *       {@link ServiceLookup#getServices(IRI)} for {@link NPS#NANOPUB_REGISTRY_1_0}.
+     *       Bootstrap servers come first; discovered servers are appended without duplicates.</li>
+     * </ol>
+     * Cached for the JVM lifetime.
+     *
+     * @return a list of registry server URLs
+     */
+    public static synchronized List<String> getRegistryServerList() {
+        if (registryServerList != null) return registryServerList;
+        String override = System.getProperty(REGISTRY_INSTANCES_PROPERTY);
+        if (override == null || override.isEmpty()) override = System.getenv(REGISTRY_INSTANCES_ENV);
+        if (override != null && !override.trim().isEmpty()) {
+            List<String> list = new ArrayList<>();
+            for (String url : override.trim().split("\\s+")) list.add(url);
+            logger.info("Using {} registry instance(s) from override", list.size());
+            registryServerList = list;
+            return registryServerList;
+        }
+        List<String> bootstrap = getBootstrapServerList();
+        List<String> discovered = ServiceLookup.getServices(NPS.NANOPUB_REGISTRY_1_0);
+        LinkedHashSet<String> union = new LinkedHashSet<>(bootstrap);
+        union.addAll(discovered);
+        logger.info("Using {} registry instance(s): {} bootstrap + {} discovered",
+                union.size(), bootstrap.size(), discovered.size());
+        registryServerList = new ArrayList<>(union);
+        return registryServerList;
     }
 
     /**

--- a/src/main/java/org/nanopub/extra/server/ServerIterator.java
+++ b/src/main/java/org/nanopub/extra/server/ServerIterator.java
@@ -39,7 +39,7 @@ public class ServerIterator implements Iterator<RegistryInfo> {
             }
         }
         if (cachedServers == null) {
-            serversToContact.addAll(NanopubServerUtils.getBootstrapServerList());
+            serversToContact.addAll(NanopubServerUtils.getRegistryServerList());
         }
     }
 

--- a/src/main/java/org/nanopub/extra/services/ServiceLookup.java
+++ b/src/main/java/org/nanopub/extra/services/ServiceLookup.java
@@ -8,6 +8,7 @@ import org.nanopub.Nanopub;
 import org.nanopub.extra.index.IndexUtils;
 import org.nanopub.extra.index.NanopubIndex;
 import org.nanopub.extra.server.GetNanopub;
+import org.nanopub.extra.server.NanopubServerUtils;
 import org.nanopub.extra.setting.NanopubSetting;
 import org.nanopub.vocabulary.NPX;
 import org.slf4j.Logger;
@@ -53,7 +54,8 @@ public class ServiceLookup {
                 cache.put(typeIri, urls);
                 return urls;
             }
-            Nanopub collectionNp = GetNanopub.get(collectionIri.stringValue());
+            List<String> bootstrap = NanopubServerUtils.getBootstrapServerList();
+            Nanopub collectionNp = GetNanopub.get(collectionIri.stringValue(), bootstrap);
             if (collectionNp == null) {
                 logger.error("Could not retrieve service intro collection: {}", collectionIri);
                 cache.put(typeIri, urls);
@@ -62,7 +64,7 @@ public class ServiceLookup {
             NanopubIndex index = IndexUtils.castToIndex(collectionNp);
             for (IRI elementIri : index.getElements()) {
                 try {
-                    Nanopub introNp = GetNanopub.get(elementIri.stringValue());
+                    Nanopub introNp = GetNanopub.get(elementIri.stringValue(), bootstrap);
                     if (introNp == null) {
                         logger.warn("Could not retrieve service intro nanopub: {}", elementIri);
                         continue;

--- a/src/test/java/org/nanopub/extra/server/NanopubServerUtilsTest.java
+++ b/src/test/java/org/nanopub/extra/server/NanopubServerUtilsTest.java
@@ -1,18 +1,56 @@
 package org.nanopub.extra.server;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.nanopub.MalformedNanopubException;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubAlreadyFinalizedException;
 import org.nanopub.NanopubCreator;
+import org.nanopub.extra.services.ServiceLookup;
 import org.nanopub.utils.TestUtils;
+import org.nanopub.vocabulary.NPS;
 import org.nanopub.vocabulary.NPX;
 
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NanopubServerUtilsTest {
+
+    private static String overridePropertyOld;
+
+    @BeforeAll
+    static void beforeAll() {
+        overridePropertyOld = System.getProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (overridePropertyOld == null) {
+            System.clearProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+        } else {
+            System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, overridePropertyOld);
+        }
+    }
+
+    @BeforeEach
+    @AfterEach
+    void resetCaches() throws NoSuchFieldException, IllegalAccessException {
+        System.clearProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+        Field f = NanopubServerUtils.class.getDeclaredField("registryServerList");
+        f.setAccessible(true);
+        f.set(null, null);
+        ServiceLookup.clearCache();
+    }
 
     @Test
     void isProtectedNanopubTrue() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
@@ -28,6 +66,57 @@ class NanopubServerUtilsTest {
     void isProtectedNanopubFalse() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
         Nanopub nanopub = TestUtils.createNanopub();
         assertFalse(NanopubServerUtils.isProtectedNanopub(nanopub));
+    }
+
+    @Test
+    void getRegistryServerListUsesOverride() {
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY,
+                "https://reg-a.example/  https://reg-b.example/");
+        assertEquals(
+                List.of("https://reg-a.example/", "https://reg-b.example/"),
+                NanopubServerUtils.getRegistryServerList());
+    }
+
+    @Test
+    void getRegistryServerListUnionsBootstrapAndDiscovered() throws Exception {
+        List<String> bootstrap = NanopubServerUtils.getBootstrapServerList();
+        // Pick one real bootstrap URL to verify dedupe, plus a fresh URL to verify appending.
+        String duplicateOfBootstrap = bootstrap.get(0);
+        String freshDiscovered = "https://discovered.example/";
+        seedServiceLookupCache(NPS.NANOPUB_REGISTRY_1_0,
+                List.of(duplicateOfBootstrap, freshDiscovered));
+
+        List<String> result = NanopubServerUtils.getRegistryServerList();
+
+        assertEquals(bootstrap.size() + 1, result.size(),
+                "Discovered URL that duplicates a bootstrap entry should be deduped");
+        assertEquals(bootstrap, result.subList(0, bootstrap.size()),
+                "Bootstrap URLs should appear first and in original order");
+        assertEquals(freshDiscovered, result.get(result.size() - 1),
+                "Fresh discovered URL should be appended at the end");
+        for (String b : bootstrap) {
+            assertEquals(1, result.stream().filter(b::equals).count(),
+                    "Bootstrap URL " + b + " should appear exactly once");
+        }
+    }
+
+    @Test
+    void getRegistryServerListIsCached() throws Exception {
+        seedServiceLookupCache(NPS.NANOPUB_REGISTRY_1_0, List.of("https://x.example/"));
+        List<String> first = NanopubServerUtils.getRegistryServerList();
+
+        // Mutate the override after the first call. The cached result should be unaffected.
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, "https://y.example/");
+        List<String> second = NanopubServerUtils.getRegistryServerList();
+
+        assertEquals(first, second);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void seedServiceLookupCache(IRI typeIri, List<String> urls) throws Exception {
+        Field f = ServiceLookup.class.getDeclaredField("cache");
+        f.setAccessible(true);
+        ((Map<IRI, List<String>>) f.get(null)).put(typeIri, urls);
     }
 
 }


### PR DESCRIPTION
## Summary

Mirrors PR #78 (query-instance discovery) for registry servers. Adds two override layers and setting-driven discovery, while keeping bootstrap servers as the seed needed to resolve the service intro collection in the first place.

- **Override** (replaces both bootstrap and discovery): \`nanopub.registry.instances\` system property / \`NANOPUB_REGISTRY_INSTANCES\` env var, whitespace-separated URLs.
- **Default**: union of the setting's bootstrap services and \`ServiceLookup.getServices(NPS.NANOPUB_REGISTRY_1_0)\`. Bootstrap entries come first; discovered URLs are appended without duplicates.
- \`ServerIterator()\`'s no-arg constructor now seeds from the new \`NanopubServerUtils.getRegistryServerList()\`.

### Bootstrap stays

Bootstrap links remain in the setting and are still consulted — they're the seed needed to fetch the service intro collection. Without them, \`ServiceLookup\` couldn't resolve which registries exist in the first place. The narrowed role: bootstrap = seed, registry list = working set.

### Recursion fix

\`ServiceLookup.getServices()\` calls \`GetNanopub.get(iri)\`, which builds a no-arg \`ServerIterator\`, which (with this PR) consults \`getRegistryServerList()\`, which calls \`ServiceLookup\` — infinite recursion. Fix: new \`GetNanopub.get(String, List<String> seedServers)\` overload that constructs \`ServerIterator(seedServers)\` directly. \`ServiceLookup\` uses this overload with the bootstrap list, dedicating bootstrap to its one job (seeding discovery) and breaking the cycle.

### Backwards compatibility

Verified against live registries: in production today the bootstrap and discovered lists fully overlap (\`3 bootstrap + 3 discovered\` → 3 in union), so the default-path seed list is identical to today's. The union design guarantees the seed is always a superset of today's bootstrap list, so any nanopub reachable today remains reachable. Override is opt-in only.

## Test plan

- [x] \`mvn test\` — all 502 tests pass
- [x] New \`NanopubServerUtilsTest\` cases cover override path, bootstrap ∪ discovered with dedupe, and JVM-lifetime caching
- [x] Manual smoke tests against live registries:
  - Default: \`Using 3 registry instance(s): 3 bootstrap + 3 discovered\` → fetched
  - System property (1 URL): \`Using 1 registry instance(s) from override\` → fetched
  - Env var (2 URLs): \`Using 2 registry instance(s) from override\` → fetched
  - Bogus-only override: \`Using 1 registry instance(s) from override\` → \`NOT FOUND\` (override correctly does not fall through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)