### PR TITLE
feat(services): gate query instances on Nanopub-Query-Status header

### DIFF
--- a/src/main/java/org/nanopub/extra/services/QueryCall.java
+++ b/src/main/java/org/nanopub/extra/services/QueryCall.java
@@ -1,5 +1,6 @@
 package org.nanopub.extra.services;
 
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.util.EntityUtils;
@@ -10,8 +11,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Second-generation query API call.
@@ -56,6 +61,80 @@ public class QueryCall {
             }
         }
         return DEFAULT_PARALLEL_CALL_COUNT;
+    }
+
+    /**
+     * HTTP response header carrying the query instance's sync state.
+     * See nanopub-query's {@code StatusController}.
+     */
+    public static final String QUERY_STATUS_HEADER = "Nanopub-Query-Status";
+
+    /**
+     * System property setting the cool-down (in seconds) before a query instance
+     * evicted for non-ready status is re-considered. Default
+     * {@value #DEFAULT_EVICTION_COOLDOWN_SECONDS}. Env var
+     * {@code NANOPUB_QUERY_EVICTION_COOLDOWN_SECONDS} also accepted.
+     */
+    public static final String EVICTION_COOLDOWN_PROPERTY = "nanopub.query.eviction-cooldown-seconds";
+
+    /**
+     * Environment variable equivalent of {@link #EVICTION_COOLDOWN_PROPERTY}.
+     */
+    public static final String EVICTION_COOLDOWN_ENV = "NANOPUB_QUERY_EVICTION_COOLDOWN_SECONDS";
+
+    private static final int DEFAULT_EVICTION_COOLDOWN_SECONDS = 300;
+
+    private static final ConcurrentMap<String, Long> evictedUntil = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the eviction cool-down in milliseconds, resolved from
+     * {@link #EVICTION_COOLDOWN_PROPERTY}, {@link #EVICTION_COOLDOWN_ENV},
+     * or the default of {@value #DEFAULT_EVICTION_COOLDOWN_SECONDS} seconds.
+     */
+    public static long getEvictionCooldownMillis() {
+        String value = System.getProperty(EVICTION_COOLDOWN_PROPERTY);
+        if (value == null || value.isEmpty()) value = System.getenv(EVICTION_COOLDOWN_ENV);
+        if (value != null && !value.trim().isEmpty()) {
+            try {
+                long n = Long.parseLong(value.trim());
+                if (n >= 0) return n * 1000L;
+                logger.warn("Ignoring {}={}: must be >= 0", EVICTION_COOLDOWN_PROPERTY, value);
+            } catch (NumberFormatException ex) {
+                logger.warn("Ignoring {}={}: not a number", EVICTION_COOLDOWN_PROPERTY, value);
+            }
+        }
+        return DEFAULT_EVICTION_COOLDOWN_SECONDS * 1000L;
+    }
+
+    /**
+     * Returns true if the response's {@link #QUERY_STATUS_HEADER} signals a
+     * fully-synced state ({@code READY} or {@code LOADING_UPDATES}). Missing
+     * header is treated as ready for backwards compatibility with older
+     * query instances.
+     */
+    static boolean isReadyStatus(HttpResponse resp) {
+        Header h = resp.getFirstHeader(QUERY_STATUS_HEADER);
+        if (h == null) return true;
+        String v = h.getValue();
+        if (v == null || v.isEmpty()) return true;
+        String upper = v.toUpperCase(Locale.ROOT);
+        return upper.equals("READY") || upper.equals("LOADING_UPDATES");
+    }
+
+    private static void evict(String apiUrl, String reason) {
+        long until = System.currentTimeMillis() + getEvictionCooldownMillis();
+        evictedUntil.put(apiUrl, until);
+        logger.warn("Evicting Nanopub Query instance {} until {} ({})", apiUrl, new Date(until), reason);
+    }
+
+    private static List<String> filterEvicted(List<String> instances) {
+        long now = System.currentTimeMillis();
+        List<String> result = new ArrayList<>(instances.size());
+        for (String url : instances) {
+            Long until = evictedUntil.get(url);
+            if (until == null || until <= now) result.add(url);
+        }
+        return result;
     }
 
     /**
@@ -125,12 +204,17 @@ public class QueryCall {
             try {
                 logger.info("Checking API instance: {}", a);
                 HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(a));
-                EntityUtils.consumeQuietly(resp.getEntity());
-                if (wasSuccessful(resp)) {
+                if (!wasSuccessful(resp)) {
+                    EntityUtils.consumeQuietly(resp.getEntity());
+                    logger.error("FAILURE: Nanopub Query instance isn't accessible: {}", a);
+                } else if (!isReadyStatus(resp)) {
+                    Header h = resp.getFirstHeader(QUERY_STATUS_HEADER);
+                    EntityUtils.consumeQuietly(resp.getEntity());
+                    logger.error("FAILURE: Nanopub Query instance not ready (status={}): {}", h.getValue(), a);
+                } else {
+                    EntityUtils.consumeQuietly(resp.getEntity());
                     logger.info("SUCCESS: Nanopub Query instance is accessible: {}", a);
                     checkedApiInstances.add(a);
-                } else {
-                    logger.error("FAILURE: Nanopub Query instance isn't accessible: {}", a);
                 }
             } catch (IOException ex) {
                 logger.error("FAILURE: Nanopub Query instance isn't accessible: {}", a);
@@ -173,7 +257,12 @@ public class QueryCall {
     }
 
     private void run() throws NotEnoughAPIInstancesException {
-        List<String> apiInstancesToTry = new LinkedList<>(getApiInstances());
+        List<String> candidates = filterEvicted(getApiInstances());
+        if (candidates.isEmpty()) {
+            throw new NotEnoughAPIInstancesException(
+                    "All Nanopub Query instances are currently evicted (loading/resetting); try again later");
+        }
+        List<String> apiInstancesToTry = new LinkedList<>(candidates);
         int parallelCallCount = getParallelCallCount();
         while (!apiInstancesToTry.isEmpty() && apisToCall.size() < parallelCallCount) {
             int randomIndex = (int) ((Math.random() * apiInstancesToTry.size()));
@@ -237,7 +326,14 @@ public class QueryCall {
                 if (!wasSuccessfulNonempty(resp)) {
                     throw new IOException(resp.getStatusLine().toString());
                 }
-                finished(this, resp, apiUrl);
+                if (!isReadyStatus(resp)) {
+                    Header h = resp.getFirstHeader(QUERY_STATUS_HEADER);
+                    String status = h == null ? "missing" : h.getValue();
+                    evict(apiUrl, "status " + status);
+                    EntityUtils.consumeQuietly(resp.getEntity());
+                } else {
+                    finished(this, resp, apiUrl);
+                }
             } catch (Exception ex) {
                 if (resp != null) EntityUtils.consumeQuietly(resp.getEntity());
                 logger.error("Request to {} was not successful: {}", apiUrl, ex.getMessage());

--- a/src/test/java/org/nanopub/extra/services/QueryCallTest.java
+++ b/src/test/java/org/nanopub/extra/services/QueryCallTest.java
@@ -26,6 +26,7 @@ public class QueryCallTest {
     @BeforeEach
     void setUp() throws IOException, NoSuchFieldException, IllegalAccessException {
         resetCheckedApiInstances();
+        clearEvictedUntil();
         ServiceLookup.clearCache();
         mockNanopubUtils = new MockNanopubUtils();
         System.setProperty(QueryCall.QUERY_INSTANCES_PROPERTY, DEFAULT_INSTANCES);
@@ -35,6 +36,7 @@ public class QueryCallTest {
     @AfterEach
     void tearDown() throws NoSuchFieldException, IllegalAccessException {
         resetCheckedApiInstances();
+        clearEvictedUntil();
         mockNanopubUtils.close();
     }
 
@@ -42,6 +44,13 @@ public class QueryCallTest {
         Field field = QueryCall.class.getDeclaredField("checkedApiInstances");
         field.setAccessible(true);
         field.set(null, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void clearEvictedUntil() throws NoSuchFieldException, IllegalAccessException {
+        Field field = QueryCall.class.getDeclaredField("evictedUntil");
+        field.setAccessible(true);
+        ((java.util.Map<String, Long>) field.get(null)).clear();
     }
 
     @AfterAll
@@ -119,6 +128,99 @@ public class QueryCallTest {
             assertEquals(2, QueryCall.getParallelCallCount());
         } finally {
             System.clearProperty(QueryCall.PARALLEL_CALL_COUNT_PROPERTY);
+        }
+    }
+
+    // --- Status-header gate ---
+
+    @Test
+    void getApiInstancesAdmitsReadyStatus() throws NotEnoughAPIInstancesException {
+        mockNanopubUtils.setHttpResponseStatusCode(200);
+        mockNanopubUtils.setNanopubQueryStatus("READY");
+        assertEquals(List.of(DEFAULT_INSTANCES.split(" ")), QueryCall.getApiInstances());
+    }
+
+    @Test
+    void getApiInstancesAdmitsLoadingUpdatesStatus() throws NotEnoughAPIInstancesException {
+        mockNanopubUtils.setHttpResponseStatusCode(200);
+        mockNanopubUtils.setNanopubQueryStatus("LOADING_UPDATES");
+        assertEquals(List.of(DEFAULT_INSTANCES.split(" ")), QueryCall.getApiInstances());
+    }
+
+    @Test
+    void getApiInstancesAdmitsMissingStatusHeader() throws NotEnoughAPIInstancesException {
+        // Older instances may not set the header at all — must still be admitted.
+        mockNanopubUtils.setHttpResponseStatusCode(200);
+        mockNanopubUtils.setNanopubQueryStatus(null);
+        assertEquals(List.of(DEFAULT_INSTANCES.split(" ")), QueryCall.getApiInstances());
+    }
+
+    @Test
+    void getApiInstancesRejectsLoadingInitialStatus() {
+        mockNanopubUtils.setHttpResponseStatusCode(200);
+        mockNanopubUtils.setNanopubQueryStatus("LOADING_INITIAL");
+        assertThrows(NotEnoughAPIInstancesException.class, QueryCall::getApiInstances);
+    }
+
+    @Test
+    void getApiInstancesRejectsResettingStatus() {
+        mockNanopubUtils.setHttpResponseStatusCode(200);
+        mockNanopubUtils.setNanopubQueryStatus("RESETTING");
+        assertThrows(NotEnoughAPIInstancesException.class, QueryCall::getApiInstances);
+    }
+
+    @Test
+    void isReadyStatusHelper() {
+        org.apache.http.HttpResponse resp = org.mockito.Mockito.mock(org.apache.http.HttpResponse.class);
+        // No header => ready (backwards compat).
+        org.mockito.Mockito.when(resp.getFirstHeader(QueryCall.QUERY_STATUS_HEADER)).thenReturn(null);
+        assertEquals(true, QueryCall.isReadyStatus(resp));
+
+        for (String good : List.of("READY", "ready", "Loading_Updates", "LOADING_UPDATES")) {
+            org.apache.http.Header h = org.mockito.Mockito.mock(org.apache.http.Header.class);
+            org.mockito.Mockito.when(h.getValue()).thenReturn(good);
+            org.mockito.Mockito.when(resp.getFirstHeader(QueryCall.QUERY_STATUS_HEADER)).thenReturn(h);
+            assertEquals(true, QueryCall.isReadyStatus(resp), good + " should be ready");
+        }
+        for (String bad : List.of("LAUNCHING", "LOADING_INITIAL", "RESETTING", "unknown")) {
+            org.apache.http.Header h = org.mockito.Mockito.mock(org.apache.http.Header.class);
+            org.mockito.Mockito.when(h.getValue()).thenReturn(bad);
+            org.mockito.Mockito.when(resp.getFirstHeader(QueryCall.QUERY_STATUS_HEADER)).thenReturn(h);
+            assertEquals(false, QueryCall.isReadyStatus(resp), bad + " should not be ready");
+        }
+    }
+
+    // --- Eviction cool-down ---
+
+    @Test
+    void getEvictionCooldownMillisDefault() {
+        System.clearProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY);
+        assertEquals(300_000L, QueryCall.getEvictionCooldownMillis());
+    }
+
+    @Test
+    void getEvictionCooldownMillisFromProperty() {
+        System.setProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY, "60");
+        try {
+            assertEquals(60_000L, QueryCall.getEvictionCooldownMillis());
+        } finally {
+            System.clearProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY);
+        }
+    }
+
+    @Test
+    void getEvictionCooldownMillisIgnoresInvalidValues() {
+        System.setProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY, "-5");
+        try {
+            assertEquals(300_000L, QueryCall.getEvictionCooldownMillis());
+        } finally {
+            System.clearProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY);
+        }
+        System.setProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY, "banana");
+        try {
+            assertEquals(300_000L, QueryCall.getEvictionCooldownMillis());
+        } finally {
+            System.clearProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY);
         }
     }
 

--- a/src/test/java/org/nanopub/utils/MockNanopubUtils.java
+++ b/src/test/java/org/nanopub/utils/MockNanopubUtils.java
@@ -1,5 +1,6 @@
 package org.nanopub.utils;
 
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -10,12 +11,14 @@ import org.nanopub.NanopubUtils;
 
 import java.io.IOException;
 
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 public class MockNanopubUtils implements AutoCloseable {
 
     private final MockedStatic<NanopubUtils> mockedStatic;
     private final StatusLine mockStatusLine = mock(StatusLine.class);
+    private volatile String nanopubQueryStatusValue = null;
 
     public MockNanopubUtils() throws IOException {
         this.mockedStatic = mockStatic(NanopubUtils.class);
@@ -27,12 +30,32 @@ public class MockNanopubUtils implements AutoCloseable {
             CloseableHttpResponse response = mock(CloseableHttpResponse.class);
             when(response.getStatusLine()).thenReturn(mockStatusLine);
             when(response.getEntity()).thenReturn(mock(HttpEntity.class));
+            // By default getFirstHeader returns null (Mockito default).
+            // When a status value is set, stub it via the read-side field.
+            when(response.getFirstHeader(anyString())).thenAnswer(inv -> {
+                String name = inv.getArgument(0);
+                if ("Nanopub-Query-Status".equalsIgnoreCase(name) && nanopubQueryStatusValue != null) {
+                    Header h = mock(Header.class);
+                    when(h.getValue()).thenReturn(nanopubQueryStatusValue);
+                    return h;
+                }
+                return null;
+            });
             return response;
         });
     }
 
     public void setHttpResponseStatusCode(int statusCode) {
         when(mockStatusLine.getStatusCode()).thenReturn(statusCode);
+    }
+
+    /**
+     * Sets the value of the {@code Nanopub-Query-Status} header returned on
+     * every mocked response. Pass {@code null} to omit the header entirely
+     * (simulating an older instance with no status reporting).
+     */
+    public void setNanopubQueryStatus(String status) {
+        this.nanopubQueryStatusValue = status;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Today, a query instance is treated as healthy when its root URL responds with HTTP 200 — which is satisfied even by instances in \`LOADING_INITIAL\` or \`RESETTING\`. Queries against such an instance return valid-looking CSV with incomplete data, with no error.

The \`nanopub-query\` server already advertises its sync state via the \`Nanopub-Query-Status\` header on every response. This PR consumes it.

### Two complementary checks

1. **Startup liveness gate** (\`getApiInstances()\`): admit only instances reporting status \`READY\` or \`LOADING_UPDATES\` (or omitting the header — older instances stay admitted for backwards compatibility). Loading / resetting states are rejected with a distinct \`FAILURE: ... not ready (status=...)\` log line.

2. **Per-call verification** (\`Call.run()\`): after a successful HTTP response, re-check the status header before accepting the response. Non-ready responses trigger a **cool-down eviction** (default 300s, configurable via \`nanopub.query.eviction-cooldown-seconds\` / env var) and are discarded; the existing parallel-call race moves on.

### Why cool-down rather than periodic re-checks

After cool-down expires, the instance is automatically eligible again; the next real call's header check re-validates it. No background thread, no fixed-interval pings, self-healing. \`LOADING_UPDATES\` is intentionally *not* an evictable state — it's the normal incremental-sync state and data is still current minus a tiny tail.

### All-evicted handling

If every instance is currently evicted, \`QueryCall.run()\` throws \`NotEnoughAPIInstancesException\` immediately with a clear message, rather than waiting through retries. For queries, returning an error beats returning stale data.

### Live-instance verification

All three live query instances currently report \`Nanopub-Query-Status: READY\` and pass the new gate cleanly:

\`\`\`
Nanopub-Query-Status: READY
Nanopub-Query-Registry-Url: https://registry.knowledgepixels.com/
Nanopub-Query-Load-Counter: 81403
Nanopub-Query-Registry-Coverage-Types: all
Nanopub-Query-Registry-Coverage-Agents: viaSetting
Nanopub-Query-Registry-Test-Instance: false
\`\`\`

## Configuration

| Property | Env var | Default | Meaning |
|---|---|---|---|
| \`nanopub.query.eviction-cooldown-seconds\` | \`NANOPUB_QUERY_EVICTION_COOLDOWN_SECONDS\` | \`300\` | How long an instance stays evicted after a non-ready response |

## Out of scope (potential follow-ups)

- Same gate for **registry** instances via \`Nanopub-Registry-Status\` — symmetric problem, separate PR.
- **Coverage-Types / Coverage-Agents** filtering: harder, callers would need to declare what slice of the corpus they need.
- **Setup-Id consistency** between a query and its declared upstream registry — only meaningful when caller can cross-check across instances.

## Test plan

- [x] \`mvn test\` — 515/515 pass (9 new tests: 5 for status gate paths incl. backwards-compat for missing header; 1 for the \`isReadyStatus\` helper across READY/LOADING_UPDATES/various bad states; 3 for cool-down config parsing)
- [x] \`MockNanopubUtils\` extended to set a configurable \`Nanopub-Query-Status\` value on mocked responses
- [x] Manual smoke test: default CLI \`query\` against live API — 3 healthy instances all pass the gate, query returns the expected CSV result

🤖 Generated with [Claude Code](https://claude.com/claude-code)