### PR TITLE
fix(services): re-check query instances rejected at startup after cool-down

### DIFF
--- a/src/main/java/org/nanopub/extra/services/QueryCall.java
+++ b/src/main/java/org/nanopub/extra/services/QueryCall.java
@@ -193,39 +193,49 @@ public class QueryCall {
      *
      * @return a list of accessible query API instances
      */
-    public static List<String> getApiInstances() throws NotEnoughAPIInstancesException {
-        if (checkedApiInstances != null) return checkedApiInstances;
+    public static synchronized List<String> getApiInstances() throws NotEnoughAPIInstancesException {
         List<String> candidates = resolveCandidateInstances();
         if (candidates.isEmpty()) {
             throw new NotEnoughAPIInstancesException("No query API instances configured or discoverable");
         }
-        checkedApiInstances = new ArrayList<>();
+        if (checkedApiInstances == null) checkedApiInstances = new ArrayList<>();
+        long now = System.currentTimeMillis();
+        boolean anyNewAdmitted = false;
         for (String a : candidates) {
+            if (checkedApiInstances.contains(a)) continue;
+            Long until = evictedUntil.get(a);
+            if (until != null && until > now) continue;
             try {
                 logger.info("Checking API instance: {}", a);
                 HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(a));
                 if (!wasSuccessful(resp)) {
                     EntityUtils.consumeQuietly(resp.getEntity());
                     logger.error("FAILURE: Nanopub Query instance isn't accessible: {}", a);
+                    evict(a, "not accessible");
                 } else if (!isReadyStatus(resp)) {
                     Header h = resp.getFirstHeader(QUERY_STATUS_HEADER);
+                    String status = h == null ? "missing" : h.getValue();
                     EntityUtils.consumeQuietly(resp.getEntity());
-                    logger.error("FAILURE: Nanopub Query instance not ready (status={}): {}", h.getValue(), a);
+                    logger.error("FAILURE: Nanopub Query instance not ready (status={}): {}", status, a);
+                    evict(a, "status " + status);
                 } else {
                     EntityUtils.consumeQuietly(resp.getEntity());
                     logger.info("SUCCESS: Nanopub Query instance is accessible: {}", a);
                     checkedApiInstances.add(a);
+                    anyNewAdmitted = true;
                 }
             } catch (IOException ex) {
                 logger.error("FAILURE: Nanopub Query instance isn't accessible: {}", a);
+                evict(a, "not accessible");
             }
         }
-        logger.info("{} accessible Nanopub Query instances", checkedApiInstances.size());
+        if (anyNewAdmitted) {
+            logger.info("{} accessible Nanopub Query instances", checkedApiInstances.size());
+        }
         if (checkedApiInstances.isEmpty()) {
-            checkedApiInstances = null;
             throw new NotEnoughAPIInstancesException("No healthy Nanopub Query instances available");
         }
-        if (checkedApiInstances.size() == 1) {
+        if (anyNewAdmitted && checkedApiInstances.size() == 1) {
             logger.warn("Only one healthy Nanopub Query instance available; no failover.");
         }
         return checkedApiInstances;

--- a/src/test/java/org/nanopub/extra/services/QueryCallTest.java
+++ b/src/test/java/org/nanopub/extra/services/QueryCallTest.java
@@ -209,6 +209,59 @@ public class QueryCallTest {
     }
 
     @Test
+    void getApiInstancesEvictsFailedAtStartup() throws Exception {
+        // Status 300 means wasSuccessful() returns false for every candidate.
+        mockNanopubUtils.setHttpResponseStatusCode(300);
+        assertThrows(NotEnoughAPIInstancesException.class, QueryCall::getApiInstances);
+        // Every candidate should now be sitting in the eviction map.
+        Field f = QueryCall.class.getDeclaredField("evictedUntil");
+        f.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Long> map = (java.util.Map<String, Long>) f.get(null);
+        for (String url : DEFAULT_INSTANCES.split(" ")) {
+            assertEquals(true, map.containsKey(url),
+                    "Failed-at-startup URL should be tracked in eviction map: " + url);
+        }
+    }
+
+    @Test
+    void getApiInstancesReadmitsAfterCooldownExpires() throws NotEnoughAPIInstancesException {
+        // Cool-down 0 means a failed instance is immediately eligible again on
+        // the next call — simulating cool-down expiry.
+        System.setProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY, "0");
+        try {
+            // First call: all instances fail liveness.
+            mockNanopubUtils.setHttpResponseStatusCode(300);
+            assertThrows(NotEnoughAPIInstancesException.class, QueryCall::getApiInstances);
+
+            // Now they become healthy. With a long cool-down they would stay
+            // excluded for the JVM; with cool-down 0 the next call re-checks
+            // them and admits them.
+            mockNanopubUtils.setHttpResponseStatusCode(200);
+            assertEquals(List.of(DEFAULT_INSTANCES.split(" ")), QueryCall.getApiInstances());
+        } finally {
+            System.clearProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY);
+        }
+    }
+
+    @Test
+    void getApiInstancesReadmitsAfterStatusFlipsToReady() throws NotEnoughAPIInstancesException {
+        System.setProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY, "0");
+        try {
+            // Reachable but reports LOADING_INITIAL: rejected at startup.
+            mockNanopubUtils.setHttpResponseStatusCode(200);
+            mockNanopubUtils.setNanopubQueryStatus("LOADING_INITIAL");
+            assertThrows(NotEnoughAPIInstancesException.class, QueryCall::getApiInstances);
+
+            // Flips to READY: next call re-checks (cool-down 0) and admits.
+            mockNanopubUtils.setNanopubQueryStatus("READY");
+            assertEquals(List.of(DEFAULT_INSTANCES.split(" ")), QueryCall.getApiInstances());
+        } finally {
+            System.clearProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY);
+        }
+    }
+
+    @Test
     void getEvictionCooldownMillisIgnoresInvalidValues() {
         System.setProperty(QueryCall.EVICTION_COOLDOWN_PROPERTY, "-5");
         try {


### PR DESCRIPTION
## Summary

Closes a long-running-JVM gap from #81. `QueryCall.getApiInstances()` cached its admitted set on first call and never re-checked candidates that failed the startup gate — so an instance that was `LOADING_INITIAL` at the moment a process boots stayed excluded for the JVM's lifetime, even after recovery. Only mid-flight evictions (a previously-admitted instance that flipped to non-ready) were self-healing.

The asymmetry was easy to miss because for short-lived CLI invocations it never mattered, and for healthy steady-state it never mattered either — the gap only shows up when a long-running JVM happens to start during a peer's load window.

## What changed

`getApiInstances()` now iterates candidates on every call and:

- Skips candidates already in `checkedApiInstances` (cheap fast-path; no new HTTP calls).
- Skips candidates whose cool-down is still active (`evictedUntil` map).
- Runs the liveness + status gate on what's left.
- Failed startup attempts now land in the same `evictedUntil` map (previously they were just silently dropped). After cool-down expires they get re-checked automatically.

The method is now `synchronized` for thread safety since the cache mutates more frequently.

Registry-side equivalent already self-heals via `ServerIterator` constructing a fresh iterator per `GetNanopub.get()` call — no change needed there.

## Test plan

- [x] `mvn test` — 525/525 pass (3 new tests):
  - `getApiInstancesEvictsFailedAtStartup` — failed-at-startup URLs land in eviction map
  - `getApiInstancesReadmitsAfterCooldownExpires` — liveness failure recovers after cool-down (`cooldown=0`)
  - `getApiInstancesReadmitsAfterStatusFlipsToReady` — non-ready status recovers after cool-down
- [x] Manual smoke test against the live query API:
  - Mixed override (`https://query.knowledgepixels.com/ https://does-not-exist-9999.example/`): healthy URL admitted, bogus URL emits `WARN: Evicting ... (not accessible)` with explicit timestamp; query succeeds via the healthy peer; `WARN: Only one healthy ... no failover` correctly fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
