### PR TITLE
chore(deps): bump gson from 2.13.2 to 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <guava.version>33.6.0-jre</guava.version>
-    <gson.version>2.13.2</gson.version>
+    <gson.version>2.14.0</gson.version>
     <jcommander.version>1.82</jcommander.version>
     <mimeparse.version>0.1.3.3</mimeparse.version>
     <httpclient.version>4.5.14</httpclient.version>


### PR DESCRIPTION
## Summary

Bumps `com.google.code.gson:gson` from 2.13.2 → 2.14.0. Routine minor bump; surfaced by `mvn versions:display-dependency-updates`.

`RegistryInfo` is the main consumer on the runtime path (deserialises registry JSON), so the smoke test exercises that code.

## Test plan

- [x] `mvn test` — 525/525 pass
- [x] Manual smoke against live registry: `scripts/run.sh get <trusty-uri>` returns the nanopub cleanly — `Using 3 registry instance(s): 3 bootstrap + 3 discovered` followed by the parsed TriG body
