### PR TITLE
feat(services): support _multi_val placeholder suffix in QueryTemplate

### DIFF
--- a/src/main/java/org/nanopub/extra/services/QueryTemplate.java
+++ b/src/main/java/org/nanopub/extra/services/QueryTemplate.java
@@ -39,8 +39,8 @@ import java.util.Set;
  *   <li>{@code ?_x} &mdash; mandatory placeholder, substituted as a literal</li>
  *   <li>{@code ?__x} &mdash; optional (leading double underscore)</li>
  *   <li>{@code ?_x_iri} &mdash; substituted as an IRI</li>
- *   <li>{@code ?_x_multi} or {@code ?_x_multi_iri} &mdash; substituted inside a
- *       {@code VALUES ?_x_multi { }} block, allowing multiple values</li>
+ *   <li>{@code ?_x_multi}, {@code ?_x_multi_iri} or {@code ?_x_multi_val} &mdash; substituted
+ *       inside a {@code VALUES ?_x_multi { }} block, allowing multiple values</li>
  * </ul>
  */
 public class QueryTemplate implements Serializable {
@@ -344,10 +344,10 @@ public class QueryTemplate implements Serializable {
 
     /**
      * @param placeholder a placeholder name
-     * @return true if multi-valued (ends with {@code _multi} or {@code _multi_iri})
+     * @return true if multi-valued (ends with {@code _multi}, {@code _multi_iri} or {@code _multi_val})
      */
     public static boolean isMultiPlaceholder(String placeholder) {
-        return placeholder.endsWith("_multi") || placeholder.endsWith("_multi_iri");
+        return placeholder.endsWith("_multi") || placeholder.endsWith("_multi_iri") || placeholder.endsWith("_multi_val");
     }
 
     /**
@@ -359,12 +359,12 @@ public class QueryTemplate implements Serializable {
     }
 
     /**
-     * Strips the placeholder conventions (leading underscores and {@code _iri}/{@code _multi}
-     * suffixes) to yield the simplified parameter name used as a lookup key in
-     * {@link #expandQuery(Map)}.
+     * Strips the placeholder conventions (leading underscores and the
+     * {@code _multi_val}/{@code _iri}/{@code _multi} suffixes) to yield the simplified
+     * parameter name used as a lookup key in {@link #expandQuery(Map)}.
      */
     public static String getParamName(String placeholder) {
-        return placeholder.replaceFirst("^_+", "").replaceFirst("_iri$", "").replaceFirst("_multi$", "");
+        return placeholder.replaceFirst("^_+", "").replaceFirst("_multi_val$", "").replaceFirst("_iri$", "").replaceFirst("_multi$", "");
     }
 
     /** Serializes a string as a SPARQL IRI ({@code <iri>}). */

--- a/src/test/java/org/nanopub/extra/services/QueryTemplateTest.java
+++ b/src/test/java/org/nanopub/extra/services/QueryTemplateTest.java
@@ -198,6 +198,7 @@ class QueryTemplateTest {
     void isMultiPlaceholder() {
         assertTrue(QueryTemplate.isMultiPlaceholder("foo_multi"));
         assertTrue(QueryTemplate.isMultiPlaceholder("foo_multi_iri"));
+        assertTrue(QueryTemplate.isMultiPlaceholder("foo_multi_val"));
         assertFalse(QueryTemplate.isMultiPlaceholder("foo_iri"));
         assertFalse(QueryTemplate.isMultiPlaceholder("foo"));
     }
@@ -211,6 +212,8 @@ class QueryTemplateTest {
         assertEquals("foo", QueryTemplate.getParamName("_foo_multi"));
         assertEquals("foo", QueryTemplate.getParamName("_foo_multi_iri"));
         assertEquals("foo", QueryTemplate.getParamName("__foo_multi_iri"));
+        assertEquals("foo", QueryTemplate.getParamName("_foo_multi_val"));
+        assertEquals("foo", QueryTemplate.getParamName("__foo_multi_val"));
     }
 
     @Test
@@ -351,6 +354,20 @@ class QueryTemplateTest {
         String expanded = qt.expandQuery(Map.of("tags", List.of("alpha", "beta")));
         assertTrue(expanded.contains("\"alpha\""));
         assertTrue(expanded.contains("\"beta\""));
+    }
+
+    @Test
+    void expandQueryMultiValPlaceholder() throws Exception {
+        Nanopub np = buildGrlcNanopub(
+                FAKE_TRUSTY_URI,
+                Map.of(FAKE_TRUSTY_URI + "/q1",
+                        "select ?s where { values ?_tags_multi_val {} ?s ?p ?_tags_multi_val }")
+        );
+        QueryTemplate qt = new QueryTemplate(np);
+        String expanded = qt.expandQuery(Map.of("tags", List.of("alpha", "beta")));
+        assertTrue(expanded.contains("\"alpha\""));
+        assertTrue(expanded.contains("\"beta\""));
+        assertFalse(expanded.contains("{}"), "VALUES block should have been filled");
     }
 
     @Test

--- a/src/test/java/org/nanopub/extra/services/QueryTemplateTest.java
+++ b/src/test/java/org/nanopub/extra/services/QueryTemplateTest.java
@@ -12,6 +12,7 @@ import org.nanopub.Nanopub;
 import org.nanopub.NanopubAlreadyFinalizedException;
 import org.nanopub.NanopubCreator;
 import org.nanopub.NanopubImpl;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
 import org.nanopub.extra.server.GetNanopub;
 import org.nanopub.testsuite.NanopubTestSuite;
 import org.nanopub.testsuite.TestSuiteEntry;
@@ -386,6 +387,28 @@ class QueryTemplateTest {
         String expanded = qt.expandQuery(Map.of());
         assertFalse(expanded.contains("values ?__tags_multi"),
                 "optional multi placeholder with no value should strip the VALUES block; got: " + expanded);
+        assertFalse(expanded.contains("{}"),
+                "the empty VALUES block (and its trailing dot) should be fully removed; got: " + expanded);
+        // The removed block was followed by a `.`; the result must still be valid SPARQL.
+        new SPARQLParser().parseQuery(expanded, null);
+    }
+
+    @Test
+    void expandQueryMissingMultiValRemovesValuesBlock() throws Exception {
+        Nanopub np = buildGrlcNanopub(
+                FAKE_TRUSTY_URI,
+                Map.of(FAKE_TRUSTY_URI + "/q1",
+                        "select ?s where { values ?__tags_multi_val {} . optional { ?s ?p ?__tags_multi_val } }")
+        );
+        QueryTemplate qt = new QueryTemplate(np);
+        assertTrue(qt.getPlaceholdersList().contains("__tags_multi_val"),
+                "placeholder should be detected; got " + qt.getPlaceholdersList());
+        String expanded = qt.expandQuery(Map.of());
+        assertFalse(expanded.contains("values ?__tags_multi_val"),
+                "missing _multi_val placeholder should strip the VALUES block; got: " + expanded);
+        assertFalse(expanded.contains("{}"),
+                "the empty VALUES block (and its trailing dot) should be fully removed; got: " + expanded);
+        new SPARQLParser().parseQuery(expanded, null);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Extends `QueryTemplate` to recognize the `_multi_val` placeholder suffix, matching the conventions used by Nanodash's `QueryParamField`:

- `isMultiPlaceholder` now treats `_multi_val` as multi-valued (alongside `_multi` and `_multi_iri`).
- `getParamName` now strips `_multi_val` (same ordering as `QueryParamField`: `^_+` → `_multi_val` → `_iri` → `_multi`).
- Class-level and method javadoc updated accordingly.

## Why

This closes the last behavioral gap between the three grlc-query expansion implementations. `nanopub-query`'s `GrlcSpec` already delegates to `QueryTemplate` (and picks this up for free). With this change, `QueryTemplate.expandQuery(map, false)` becomes a full behavioral superset of Nanodash's `GrlcQuery.expandQuery(List<QueryParamField>)`, so that Nanodash-specific method can later be removed in favor of converting its param fields to a `Map<String, List<String>>` and calling the inherited method.

(The other potential difference — removal of an empty `VALUES { }` block for an unfilled multi placeholder in non-strict mode — was kept as-is; `QueryTemplate` already removes it, which is the desired behavior.)

## Tests

- Added `_multi_val` cases to the `isMultiPlaceholder` and `getParamName` unit tests.
- Added `expandQueryMultiValPlaceholder`, an end-to-end test confirming a `?_tags_multi_val` placeholder expands into a filled `VALUES` block of literals.

All 34 `QueryTemplateTest` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)