### PR TITLE
fix(security): accept PEM-formatted key files in loadKey

### DIFF
--- a/src/main/java/org/nanopub/extra/security/SignNanopub.java
+++ b/src/main/java/org/nanopub/extra/security/SignNanopub.java
@@ -20,6 +20,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -258,6 +259,12 @@ public class SignNanopub extends CliRunner {
 
     /**
      * Loads a key pair from the specified key file.
+     * <p>
+     * The private key is read from the given file and the public key from the same file name with the
+     * suffix {@code .pub}. Both are expected to be base64-encoded, the private one in PKCS#8 and the
+     * public one in X.509/SubjectPublicKeyInfo format. PEM header and footer lines (such as
+     * {@code -----BEGIN PRIVATE KEY-----}) and line breaks are accepted and ignored, so plain PEM files
+     * can be used as they are produced by tools like OpenSSL.
      *
      * @param keyFilename the path to the key file
      * @param algorithm   the signature algorithm used for the key
@@ -269,13 +276,60 @@ public class SignNanopub extends CliRunner {
     public static KeyPair loadKey(String keyFilename, SignatureAlgorithm algorithm) throws NoSuchAlgorithmException, IOException, InvalidKeySpecException {
         keyFilename = SignatureUtils.getFullFilePath(keyFilename);
         KeyFactory kf = KeyFactory.getInstance(algorithm.name());
-        byte[] privateKeyBytes = DatatypeConverter.parseBase64Binary(IOUtils.toString(new FileInputStream(keyFilename), StandardCharsets.UTF_8));
-        KeySpec privateSpec = new PKCS8EncodedKeySpec(privateKeyBytes);
-        PrivateKey privateKey = kf.generatePrivate(privateSpec);
-        byte[] publicKeyBytes = DatatypeConverter.parseBase64Binary(IOUtils.toString(new FileInputStream(keyFilename + ".pub"), StandardCharsets.UTF_8));
-        KeySpec publicSpec = new X509EncodedKeySpec(publicKeyBytes);
-        PublicKey publicKey = kf.generatePublic(publicSpec);
+        String publicKeyFilename = keyFilename + ".pub";
+        String privateKeyString = readKeyFile(keyFilename);
+        String publicKeyString = readKeyFile(publicKeyFilename);
+        PrivateKey privateKey;
+        try {
+            KeySpec privateSpec = new PKCS8EncodedKeySpec(decodeKey(privateKeyString));
+            privateKey = kf.generatePrivate(privateSpec);
+        } catch (IllegalArgumentException | InvalidKeySpecException ex) {
+            throw new InvalidKeySpecException(getKeyErrorMessage(keyFilename, privateKeyString, true), ex);
+        }
+        PublicKey publicKey;
+        try {
+            KeySpec publicSpec = new X509EncodedKeySpec(decodeKey(publicKeyString));
+            publicKey = kf.generatePublic(publicSpec);
+        } catch (IllegalArgumentException | InvalidKeySpecException ex) {
+            throw new InvalidKeySpecException(getKeyErrorMessage(publicKeyFilename, publicKeyString, false), ex);
+        }
         return new KeyPair(publicKey, privateKey);
+    }
+
+    private static final Pattern pemArmorPattern = Pattern.compile("-----(BEGIN|END)[^-]*-----");
+
+    private static String readKeyFile(String keyFilename) throws IOException {
+        try (InputStream in = new FileInputStream(keyFilename)) {
+            return IOUtils.toString(in, StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Decodes a base64-encoded key, ignoring PEM header/footer lines and line breaks if present.
+     */
+    private static byte[] decodeKey(String keyString) {
+        return DatatypeConverter.parseBase64Binary(pemArmorPattern.matcher(keyString).replaceAll(""));
+    }
+
+    private static String getKeyErrorMessage(String keyFilename, String keyString, boolean isPrivateKey) {
+        String hint;
+        if (keyString.contains("BEGIN ENCRYPTED PRIVATE KEY")) {
+            hint = "The key seems to be protected by a passphrase, which is not supported. Decrypt it first and " +
+                    "use the decrypted key, e.g. with: openssl pkcs8 -topk8 -nocrypt -in " + keyFilename + " -out " + keyFilename + ".pkcs8";
+        } else if (keyString.contains("BEGIN RSA PRIVATE KEY")) {
+            hint = "The key seems to be in PKCS#1 format, which is not supported. Convert it to PKCS#8 and " +
+                    "use the converted key, e.g. with: openssl pkcs8 -topk8 -nocrypt -in " + keyFilename + " -out " + keyFilename + ".pkcs8";
+        } else if (keyString.contains("BEGIN RSA PUBLIC KEY")) {
+            hint = "The key seems to be in PKCS#1 format, which is not supported. Convert it to X.509 and " +
+                    "use the converted key, e.g. with: openssl rsa -RSAPublicKey_in -in " + keyFilename + " -pubout -out " + keyFilename + ".x509";
+        } else if (keyString.contains("BEGIN OPENSSH PRIVATE KEY") || keyString.startsWith("ssh-")) {
+            hint = "The key seems to be in OpenSSH format, which is not supported. Convert it to PKCS#8, " +
+                    "e.g. with: ssh-keygen -p -m PKCS8 -f " + keyFilename;
+        } else {
+            hint = "Expected a base64-encoded " + (isPrivateKey ? "PKCS#8 private key" : "X.509 public key") +
+                    ", with or without PEM header/footer lines.";
+        }
+        return "Could not read the " + (isPrivateKey ? "private" : "public") + " key from file " + keyFilename + ". " + hint;
     }
 
 }

--- a/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
@@ -1,35 +1,46 @@
 package org.nanopub.extra.security;
 
-import com.beust.jcommander.ParameterException;
-import net.trustyuri.TrustyUriUtils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.security.KeyPair;
+import java.security.SignatureException;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+import java.util.Comparator;
+
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.rio.RDFFormat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.nanopub.CliRunner;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubCreator;
 import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubProfile;
-import org.nanopub.testsuite.*;
+import org.nanopub.testsuite.NanopubTestSuite;
+import org.nanopub.testsuite.SigningKeyPair;
+import org.nanopub.testsuite.TestSuiteEntry;
+import org.nanopub.testsuite.TestSuiteSubfolder;
+import org.nanopub.testsuite.TransformTestCase;
 import org.nanopub.utils.TestUtils;
+import static org.nanopub.utils.TestUtils.anyIri;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.StandardCopyOption;
-import java.security.KeyPair;
-import java.security.spec.InvalidKeySpecException;
-import java.util.Base64;
-import java.security.SignatureException;
-import java.util.Comparator;
+import com.beust.jcommander.ParameterException;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.nanopub.utils.TestUtils.anyIri;
+import net.trustyuri.TrustyUriUtils;
 
 class SignNanopubTest {
 
@@ -62,10 +73,10 @@ class SignNanopubTest {
 
             // create signed nanopub file
             SignNanopub c = CliRunner.initJc(new SignNanopub(), new String[]{
-                    testFile.getPath(),
-                    "-k ", signingKeyPair.getPrivateKeyFile().getPath(),
-                    "-s ", signerOrcid,
-                    "-o ", outFile.getPath(),});
+                testFile.getPath(),
+                "-k ", signingKeyPair.getPrivateKeyFile().getPath(),
+                "-s ", signerOrcid,
+                "-o ", outFile.getPath(),});
             c.run();
 
             // read nanopub from file
@@ -102,9 +113,9 @@ class SignNanopubTest {
 
             // create signed nanopub file
             SignNanopub c = CliRunner.initJc(new SignNanopub(), new String[]{
-                    testFile.getPath(),
-                    "--profile ", profileFile,
-                    "-o ", outFile.getPath(),});
+                testFile.getPath(),
+                "--profile ", profileFile,
+                "-o ", outFile.getPath(),});
             c.run();
 
             // read nanopub from file
@@ -153,9 +164,9 @@ class SignNanopubTest {
         SigningKeyPair keySource = NanopubTestSuite.getLatest().getSigningKey("rsa-key1");
         Path keyPath = tempDir.resolve("id_rsa");
         // a key that cannot be read as PKCS#8, declaring itself to be in PKCS#1 format
-        Files.writeString(keyPath, "-----BEGIN RSA PRIVATE KEY-----\n" +
-                Base64.getEncoder().encodeToString("not a PKCS#8 key".getBytes(StandardCharsets.UTF_8)) +
-                "\n-----END RSA PRIVATE KEY-----\n");
+        Files.writeString(keyPath, "-----BEGIN RSA PRIVATE KEY-----\n"
+                + Base64.getEncoder().encodeToString("not a PKCS#8 key".getBytes(StandardCharsets.UTF_8))
+                + "\n-----END RSA PRIVATE KEY-----\n");
         Files.writeString(tempDir.resolve("id_rsa.pub"), toPem(keySource.getPublicKeyFile(), "PUBLIC KEY"));
 
         InvalidKeySpecException e = assertThrows(InvalidKeySpecException.class,
@@ -166,9 +177,12 @@ class SignNanopubTest {
 
     private String toPem(File keyFile, String label) throws IOException {
         String base64 = Files.readString(keyFile.toPath()).trim();
-        return "-----BEGIN " + label + "-----\n" +
-                String.join("\n", base64.split("(?<=\\G.{64})")) +
-                "\n-----END " + label + "-----\n";
+        return "-----BEGIN " + label + "-----\n"
+                + String.join("\n", base64.split("(?<=\\G.{64})"))
+                + "\n-----END " + label + "-----\n";
+
+    }
+
     void refusesToSignNanopubWithIllTypedLiteral() throws Exception {
         NanopubCreator creator = TestUtils.getNanopubCreator();
         creator.addAssertionStatement(anyIri, anyIri, TestUtils.vf.createLiteral("two", XSD.INTEGER));

--- a/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
@@ -16,7 +16,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.StandardCopyOption;
+import java.security.KeyPair;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -120,6 +124,45 @@ class SignNanopubTest {
                         }
                     });
         }
+    }
+
+    @Test
+    void loadKeyFromPemFiles() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-load-key-pem");
+        SigningKeyPair keySource = NanopubTestSuite.getLatest().getSigningKey("rsa-key1");
+        Path keyPath = tempDir.resolve("id_rsa");
+        Files.writeString(keyPath, toPem(keySource.getPrivateKeyFile(), "PRIVATE KEY"));
+        Files.writeString(tempDir.resolve("id_rsa.pub"), toPem(keySource.getPublicKeyFile(), "PUBLIC KEY"));
+
+        KeyPair fromPem = SignNanopub.loadKey(keyPath.toString(), SignatureAlgorithm.RSA);
+        KeyPair fromPlain = SignNanopub.loadKey(keySource.getPrivateKeyFile().getPath(), SignatureAlgorithm.RSA);
+
+        assertArrayEquals(fromPlain.getPrivate().getEncoded(), fromPem.getPrivate().getEncoded());
+        assertArrayEquals(fromPlain.getPublic().getEncoded(), fromPem.getPublic().getEncoded());
+    }
+
+    @Test
+    void loadKeyWithUnsupportedFormatReportsHelpfulMessage() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-load-key-pkcs1");
+        SigningKeyPair keySource = NanopubTestSuite.getLatest().getSigningKey("rsa-key1");
+        Path keyPath = tempDir.resolve("id_rsa");
+        // a key that cannot be read as PKCS#8, declaring itself to be in PKCS#1 format
+        Files.writeString(keyPath, "-----BEGIN RSA PRIVATE KEY-----\n" +
+                Base64.getEncoder().encodeToString("not a PKCS#8 key".getBytes(StandardCharsets.UTF_8)) +
+                "\n-----END RSA PRIVATE KEY-----\n");
+        Files.writeString(tempDir.resolve("id_rsa.pub"), toPem(keySource.getPublicKeyFile(), "PUBLIC KEY"));
+
+        InvalidKeySpecException e = assertThrows(InvalidKeySpecException.class,
+                () -> SignNanopub.loadKey(keyPath.toString(), SignatureAlgorithm.RSA));
+        assertTrue(e.getMessage().contains(keyPath.toString()), "Error message should name the key file: " + e.getMessage());
+        assertTrue(e.getMessage().contains("PKCS#1"), "Error message should mention the detected format: " + e.getMessage());
+    }
+
+    private String toPem(File keyFile, String label) throws IOException {
+        String base64 = Files.readString(keyFile.toPath()).trim();
+        return "-----BEGIN " + label + "-----\n" +
+                String.join("\n", base64.split("(?<=\\G.{64})")) +
+                "\n-----END " + label + "-----\n";
     }
 
 }

--- a/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
@@ -1,5 +1,7 @@
 package org.nanopub.extra.security;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -19,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -183,6 +186,7 @@ class SignNanopubTest {
 
     }
 
+    @Test
     void refusesToSignNanopubWithIllTypedLiteral() throws Exception {
         NanopubCreator creator = TestUtils.getNanopubCreator();
         creator.addAssertionStatement(anyIri, anyIri, TestUtils.vf.createLiteral("two", XSD.INTEGER));
@@ -198,9 +202,8 @@ class SignNanopubTest {
         SignatureException ex = assertThrows(SignatureException.class, () -> SignNanopub.signAndTransform(np, context));
         assertTrue(ex.getMessage().contains("ill-typed literal(s) and cannot be signed"));
     }
-  
-    // --------------------------------------------------------------- helpers
 
+    // --------------------------------------------------------------- helpers
     private static TransformContext transformContext(boolean ignoreSigned) throws Exception {
         SigningKeyPair keyPair = NanopubTestSuite.getLatest().getSigningKey("rsa-key1");
         KeyPair key = SignNanopub.loadKey(keyPair.getPrivateKeyFile().getPath(), SignatureAlgorithm.RSA);
@@ -219,7 +222,9 @@ class SignNanopubTest {
 
     private static File writeToFile(File directory, String name, Nanopub... nanopubs) throws Exception {
         StringBuilder trig = new StringBuilder();
-        for (Nanopub np : nanopubs) trig.append(np.writeToString(RDFFormat.TRIG));
+        for (Nanopub np : nanopubs) {
+            trig.append(np.writeToString(RDFFormat.TRIG));
+        }
         File file = new File(directory, name);
         Files.writeString(file.toPath(), trig.toString());
         return file;
@@ -230,7 +235,6 @@ class SignNanopubTest {
     }
 
     // ------------------------------------------------------- signAndTransform
-
     @Test
     void signAndTransformProducesAVerifiableSignature() throws Exception {
         Nanopub signed = SignNanopub.signAndTransform(preNanopub(), transformContext(false));
@@ -256,7 +260,6 @@ class SignNanopubTest {
     }
 
     // ------------------------------------------- signAndTransformMultiNanopub
-
     @Test
     void signAndTransformMultiNanopubFromAStream() throws Exception {
         String trig = preNanopub().writeToString(RDFFormat.TRIG);
@@ -280,14 +283,13 @@ class SignNanopubTest {
     }
 
     // ------------------------------------------------------------------- CLI
-
     @Test
     void writesNextToTheInputWhenNoOutputFileIsGiven() throws Exception {
         Path tempDir = Files.createTempDirectory("test-sign-default-output");
         File input = writeToFile(tempDir.toFile(), "input.trig", preNanopub());
 
         CliRunner.initJc(new SignNanopub(), new String[]{
-                "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()}).run();
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()}).run();
 
         File output = new File(tempDir.toFile(), "signed.input.trig");
         assertTrue(output.exists());
@@ -301,8 +303,8 @@ class SignNanopubTest {
         File output = new File(tempDir.toFile(), "out.trig.gz");
 
         CliRunner.initJc(new SignNanopub(), new String[]{
-                "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000",
-                "-o", output.getPath(), input.getPath()}).run();
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000",
+            "-o", output.getPath(), input.getPath()}).run();
 
         assertTrue(output.exists());
         try (java.io.InputStream in = new java.util.zip.GZIPInputStream(new java.io.FileInputStream(output))) {
@@ -320,7 +322,7 @@ class SignNanopubTest {
         }
 
         CliRunner.initJc(new SignNanopub(), new String[]{
-                "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()}).run();
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()}).run();
 
         File output = new File(tempDir.toFile(), "signed.input.trig.gz");
         assertTrue(output.exists());
@@ -349,7 +351,7 @@ class SignNanopubTest {
         File input = writeToFile(tempDir.toFile(), "input.trig", preNanopub());
 
         SignNanopub signer = CliRunner.initJc(new SignNanopub(), new String[]{
-                "-k", tempDir + "/missing_dsa", "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()});
+            "-k", tempDir + "/missing_dsa", "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()});
 
         // the key cannot be read, but the file name has already selected the DSA algorithm
         assertThrows(Exception.class, signer::run);
@@ -362,7 +364,7 @@ class SignNanopubTest {
         File output = new File(tempDir.toFile(), "out.trig");
 
         SignNanopub.main(new String[]{"-v", "-k", privateKeyPath(),
-                "-s", "https://orcid.org/0000-0000-0000-0000", "-o", output.getPath(), input.getPath()});
+            "-s", "https://orcid.org/0000-0000-0000-0000", "-o", output.getPath(), input.getPath()});
 
         assertTrue(output.exists());
         assertTrue(TrustyUriUtils.isPotentialTrustyUri(new NanopubImpl(output, RDFFormat.TRIG).getUri()));


### PR DESCRIPTION
Fixes #13.

## Problem

`SignNanopub.loadKey` fed the raw key-file contents straight into `DatatypeConverter.parseBase64Binary`, so any key file carrying the standard `-----BEGIN PRIVATE KEY-----` / `-----END PRIVATE KEY-----` armor failed with an opaque `InvalidKeySpecException: invalid key format`. Users had to strip the armor by hand before signing. (Newlines alone were already tolerated — the armor was the actual blocker.)

## Changes

- **Accept PEM armor.** `-----(BEGIN|END) ...-----` lines are stripped before base64-decoding, for both the private key and the `.pub` file. Standard OpenSSL PEM files now work as they are. The canonical form written into signatures is unchanged — only the input side is relaxed, matching what [nanopub-py](https://github.com/Nanopublication/nanopub-py) does in `normalize_private_key` / `normalize_public_key`.
- **Actionable errors.** Each key is decoded in its own block, so a failure names the offending file and, where detectable from the armor, the cause and a conversion command:
  - PKCS#1 private key → `openssl pkcs8 -topk8 -nocrypt`
  - PKCS#1 public key → `openssl rsa -RSAPublicKey_in -pubout`
  - Passphrase-protected key → decrypt first
  - OpenSSH key → `ssh-keygen -p -m PKCS8`

  Suggested commands write to a new file (`.pkcs8` / `.x509`) so following them can't clobber the original key.
- Drive-by: the two `FileInputStream`s were never closed; reading now goes through a try-with-resources helper.

PKCS#1 support itself is **not** implemented — it would need a PKCS#8 wrap or BouncyCastle. It is now a clear error rather than an opaque one.

## Verification

Against real OpenSSL-generated keys:

- PKCS#8 PEM with armor (the exact case from #13, failing before this change) → loads
- PKCS#1 key from `openssl genrsa -traditional` → fails with:
  > Could not read the private key from file …/p1_rsa. The key seems to be in PKCS#1 format, which is not supported. Convert it to PKCS#8 and use the converted key, e.g. with: openssl pkcs8 -topk8 -nocrypt -in …/p1_rsa -out …/p1_rsa.pkcs8

Two tests added to `SignNanopubTest`: `loadKeyFromPemFiles` armors the test-suite `rsa-key1` pair and asserts the loaded key material is byte-identical to loading the bare files; `loadKeyWithUnsupportedFormatReportsHelpfulMessage` asserts the error names the file and the detected format.

Full suite green: 584 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
