### PR TITLE
feat(verify): check that literal values are valid for their datatype

### DIFF
--- a/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
@@ -1,11 +1,15 @@
 package org.nanopub.extra.server;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.datatypes.XMLDatatypeUtil;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubUtils;
+import org.nanopub.SimpleTimestampPattern;
 import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
@@ -41,8 +45,36 @@ public class NanopubVerifier {
         checkTripleCount();
         checkByteCount();
         checkUriProtocol();
+        checkLiteralDatatypes();
 
         return issues.isEmpty();
+    }
+
+    private Set<Statement> getAllStatements() {
+        Set<Statement> allStatements = new HashSet<>();
+        allStatements.addAll(nanopub.getHead());
+        allStatements.addAll(nanopub.getAssertion());
+        allStatements.addAll(nanopub.getProvenance());
+        allStatements.addAll(nanopub.getPubinfo());
+        return allStatements;
+    }
+
+    /**
+     * Check that the value of each literal is valid for the datatype it declares. Nanopubs with
+     * malformed literals can be published, but are rejected by strict RDF stores and therefore end up
+     * being unavailable through the SPARQL endpoint.
+     */
+    private void checkLiteralDatatypes() {
+        for (Statement st : getAllStatements()) {
+            if (!(st.getObject() instanceof Literal l)) continue;
+            IRI datatype = l.getDatatype();
+            // only XML Schema datatypes have a lexical space we can check here
+            if (!XMLDatatypeUtil.isBuiltInDatatype(datatype)) continue;
+            if (!XMLDatatypeUtil.isValidValue(l.getLabel(), datatype)) {
+                issues.add("Invalid value for datatype " + datatype.stringValue() + ": \"" + l.getLabel() +
+                        "\" (as object of " + st.getPredicate().stringValue() + ")");
+            }
+        }
     }
 
     /**
@@ -55,13 +87,7 @@ public class NanopubVerifier {
     }
 
     private void checkUriProtocol() {
-        Set<Statement> allStatements = new HashSet<>();
-        allStatements.addAll(nanopub.getHead());
-        allStatements.addAll(nanopub.getAssertion());
-        allStatements.addAll(nanopub.getProvenance());
-        allStatements.addAll(nanopub.getPubinfo());
-
-        for (Statement st : allStatements) {
+        for (Statement st : getAllStatements()) {
             if (!isHttpOrHttps(st.getSubject())) {
                 issues.add("Invalid URI protocol: " + st.getSubject().stringValue());
             }
@@ -95,7 +121,7 @@ public class NanopubVerifier {
     private void checkTimestamp() {
         Calendar creationTime = nanopub.getCreationTime();
         if (creationTime == null) {
-            issues.add("Nanopub has no creation time.");
+            issues.add(getMissingTimestampIssue());
             return;
         }
         long now = new Date().getTime();
@@ -109,6 +135,21 @@ public class NanopubVerifier {
         if (creationTime.getTimeInMillis() < oneHourBeforeNow) {
             issues.add("Nanopub creation time is older than one hour." );
         }
+    }
+
+    /**
+     * A creation time that does not declare the datatype xsd:dateTime is ignored when the timestamp is
+     * read, and is therefore reported as its own issue rather than as a missing creation time.
+     */
+    private String getMissingTimestampIssue() {
+        for (Statement st : nanopub.getPubinfo()) {
+            if (!st.getSubject().equals(nanopub.getUri())) continue;
+            if (!SimpleTimestampPattern.isCreationTimeProperty(st.getPredicate())) continue;
+            if (st.getObject() instanceof Literal l && !l.getDatatype().equals(XSD.DATETIME)) {
+                return "Nanopub creation time has datatype " + l.getDatatype().stringValue() + " instead of xsd:dateTime.";
+            }
+        }
+        return "Nanopub has no creation time.";
     }
 
     private void checkHasLabel() {

--- a/src/test/java/org/nanopub/extra/server/NanopubVerifierTest.java
+++ b/src/test/java/org/nanopub/extra/server/NanopubVerifierTest.java
@@ -3,8 +3,10 @@ package org.nanopub.extra.server;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.nanopub.*;
@@ -288,6 +290,60 @@ class NanopubVerifierTest {
         NanopubVerifier verifier = new NanopubVerifier(spy);
         verifier.verify();
         assertTrue(verifier.getIssues().stream().anyMatch(s -> s.startsWith("Byte count exceeds maximum of 10MB")));
+    }
+
+    // -- checkLiteralDatatypes --
+
+    @Test
+    void checkLiteralDatatypes_validLiterals_noDatatypeProblem() throws Exception {
+        NanopubCreator c = baseCreator();
+        c.addTimestampNow();
+        c.addAssertionStatement(anyIri, anyIri, vf.createLiteral("42", XSD.INTEGER));
+        c.addAssertionStatement(anyIri, RDFS.LABEL, vf.createLiteral("plain string"));
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().stream().noneMatch(s -> s.startsWith("Invalid value for datatype")));
+    }
+
+    @Test
+    void checkLiteralDatatypes_invalidLiteral_reportsProblem() throws Exception {
+        NanopubCreator c = baseCreator();
+        c.addTimestampNow();
+        c.addAssertionStatement(anyIri, anyIri, vf.createLiteral("not-a-number", XSD.INTEGER));
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().stream().anyMatch(s ->
+                s.startsWith("Invalid value for datatype " + XSD.INTEGER + ": \"not-a-number\"")));
+    }
+
+    @Test
+    void checkLiteralDatatypes_unknownDatatype_noDatatypeProblem() throws Exception {
+        NanopubCreator c = baseCreator();
+        c.addTimestampNow();
+        // not an XML Schema datatype, so its lexical space is unknown to us and not checked
+        c.addAssertionStatement(anyIri, anyIri, vf.createLiteral("anything", vf.createIRI("https://example.org/myDatatype")));
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().stream().noneMatch(s -> s.startsWith("Invalid value for datatype")));
+    }
+
+    @Test
+    void checkTimestamp_wrongDatatype_reportsDatatypeProblem() throws Exception {
+        NanopubCreator c = baseCreator();
+        // the timestamp of issue #12: a dateTime value declared to be an integer
+        c.addPubinfoStatement(DCTERMS.CREATED, vf.createLiteral("2022-06-24T09:36:41+00:00", XSD.INTEGER));
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().contains("Nanopub creation time has datatype " + XSD.INTEGER + " instead of xsd:dateTime."));
+        assertFalse(verifier.getIssues().contains("Nanopub has no creation time."));
     }
 
 }


### PR DESCRIPTION
Refs #12.

## Problem

Nanopubs containing a literal whose value does not match its declared datatype — the case in #12 was `dct:created "2022-06-24T09:36:41+00:00"^^xsd:integer` — are published successfully but are rejected by strict RDF stores, so they never show up in the SPARQL endpoint. The issue asks that nanopub-java report this instead of quietly spreading such nanopubs.

Since then, `NanopubVerifier` and `PublishNanopub --strict` were added, which give us the place to report it. But no check covered malformed literals: RDF4J's `VERIFY_DATATYPE_VALUES` is left at its default of `false` in `NanopubUtils.getParser`, so these literals parse silently, and nothing downstream looked at them.

## Changes

- **New `checkLiteralDatatypes()`** in `NanopubVerifier`. Walks every statement of all four graphs and validates each literal's lexical form against its datatype using `XMLDatatypeUtil.isValidValue`. Only XML Schema datatypes are checked — the lexical space of a custom datatype is unknown to us — so `rdf:langString` and user-defined datatypes are skipped. The message names the datatype, the value and the predicate:

  > Invalid value for datatype http://www.w3.org/2001/XMLSchema#integer: "not-a-number" (as object of http://www.w3.org/2000/01/rdf-schema#comment)

- **`checkTimestamp()` distinguishes a mistyped creation time from an absent one.** `SimpleTimestampPattern.getCreationTime` skips any `dct:created` that is not `xsd:dateTime`, so the nanopub of #12 was reported as *"Nanopub has no creation time."*, which points away from the actual cause. It now reports:

  > Nanopub creation time has datatype http://www.w3.org/2001/XMLSchema#integer instead of xsd:dateTime.

- Drive-by: the gathering of statements from the four graphs moved out of `checkUriProtocol` into a shared `getAllStatements()` helper, now used by both checks.

## Verification

Taking `valid_graph.trig` and injecting the two defects, run against the compiled verifier:

| Case | Before | After |
| --- | --- | --- |
| `dct:created "…"^^xsd:integer` (the nanopub of #12) | "Nanopub has no creation time." — misleading | names the datatype mismatch, plus flags the invalid literal |
| `rdfs:comment "not-a-number"^^xsd:integer` | not flagged at all | flagged with datatype, value and predicate |

Four tests added to `NanopubVerifierTest`: valid literals produce no issue, an invalid one does, a custom non-XSD datatype is left alone, and the #12 timestamp yields the datatype message rather than the missing-timestamp one. Full suite: 586 tests, 0 failures.

## Scope

This makes such nanopubs detectable, and `PublishNanopub --strict` refuses to publish them. Default (non-strict) publishing still logs the issues and proceeds — turning that into a hard failure is a behavioural decision left out of this PR, which is why this is `Refs #12` rather than `Closes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
