### PR TITLE
chore(logger): unify on SLF4J and fix library logging behaviour

### DIFF
--- a/src/main/java/org/nanopub/CliRunner.java
+++ b/src/main/java/org/nanopub/CliRunner.java
@@ -2,8 +2,8 @@ package org.nanopub;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 
@@ -11,6 +11,8 @@ import java.util.Arrays;
  * Abstract class for command-line interface (CLI) runners.
  */
 public abstract class CliRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(CliRunner.class);
 
     /**
      * The JCommander instance that handles command-line arguments.
@@ -32,7 +34,7 @@ public abstract class CliRunner {
             jc.parse(args);
         } catch (ParameterException ex) {
             String arguments = "args = " + Arrays.toString(args);
-            logOrSysout(LogFactory.getLog(CliRunner.class), arguments);
+            logOrSysout(logger, arguments);
             jc.usage();
             throw ex;
         }
@@ -40,12 +42,16 @@ public abstract class CliRunner {
     }
 
     /**
-     * Depending on the LOG-LEVEL of log (if >= DEBUG), we forward the logMsg to SysOut or DEBUG LOG.
+     * Depending on the logger-LEVEL of log (if &gt;= DEBUG), we forward the logMsg to SysOut or DEBUG logger.
+     * <p>
+     * This is intended for CLI progress output only. Library code must not use it, since writing to
+     * standard output cannot be suppressed or redirected by an embedding application; log through a
+     * {@link Logger} directly instead.
      *
-     * @param log    the Log instance
+     * @param log    the Logger instance
      * @param logMsg the message to log
      */
-    protected static void logOrSysout(Log log, String logMsg) {
+    protected static void logOrSysout(Logger log, String logMsg) {
         if (log.isDebugEnabled()) {
             log.debug(logMsg);
         } else {

--- a/src/main/java/org/nanopub/HtmlWriter.java
+++ b/src/main/java/org/nanopub/HtmlWriter.java
@@ -12,6 +12,9 @@ import org.eclipse.rdf4j.rio.turtle.TurtleUtil;
 import org.eclipse.rdf4j.rio.turtle.TurtleWriter;
 
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -25,6 +28,8 @@ import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
  * An RDF writer that outputs RDF in HTML format, suitable for displaying.
  */
 public class HtmlWriter extends TurtleWriter {
+
+    private static final Logger logger = LoggerFactory.getLogger(HtmlWriter.class);
 
     private boolean inActiveContext;
     private Resource currentContext;
@@ -411,6 +416,7 @@ public class HtmlWriter extends TurtleWriter {
                 } catch (IllegalArgumentException e) {
                     // not a valid numeric typed literal. ignore error and write as
                     // quoted string instead.
+                    logger.debug("Literal \"{}\" is not a valid {}; writing it as a quoted string", label, datatype);
                 }
             }
         }

--- a/src/main/java/org/nanopub/NanopubImpl.java
+++ b/src/main/java/org/nanopub/NanopubImpl.java
@@ -22,6 +22,8 @@ import org.eclipse.rdf4j.rio.helpers.AbstractRDFHandler;
 import org.nanopub.trusty.TrustyNanopubUtils;
 import org.nanopub.vocabulary.NP;
 import org.nanopub.vocabulary.RDFG;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URISyntaxException;
@@ -36,6 +38,8 @@ import java.util.*;
  * @author Eelke van der Horst
  */
 public class NanopubImpl implements NanopubWithNs, Serializable {
+
+    private static final Logger logger = LoggerFactory.getLogger(NanopubImpl.class);
 
     static {
         tryToLoadParserFactory("org.eclipse.rdf4j.rio.trig.TriGParserFactory");
@@ -178,7 +182,8 @@ public class NanopubImpl implements NanopubWithNs, Serializable {
                 }
             }
         } catch (MalformedQueryException | QueryEvaluationException ex) {
-            ex.printStackTrace();
+            // The nanopub is left incomplete here; init() below reports it as malformed.
+            logger.error("Could not retrieve nanopub {} from the repository", nanopubUri, ex);
         }
         init();
     }
@@ -360,6 +365,7 @@ public class NanopubImpl implements NanopubWithNs, Serializable {
         checkProvenance();
         checkPubinfo();
         isValidAndTrusty = TrustyNanopubUtils.isValidTrustyNanopub(this);
+        logger.debug("Loaded nanopub {} with {} statement(s); trusty: {}", nanopubUri, statements.size(), isValidAndTrusty);
     }
 
     private void collectNanopubUri(Collection<Statement> statements) throws MalformedNanopubException {

--- a/src/main/java/org/nanopub/NanopubUtils.java
+++ b/src/main/java/org/nanopub/NanopubUtils.java
@@ -18,6 +18,8 @@ import org.nanopub.vocabulary.NP;
 import org.nanopub.vocabulary.NPX;
 import org.nanopub.vocabulary.PAV;
 import org.nanopub.vocabulary.RDFG;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -29,6 +31,8 @@ import java.util.*;
  * @author Tobias Kuhn
  */
 public class NanopubUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(NanopubUtils.class);
 
     private static final List<Pair<String, String>> defaultNamespaces = new ArrayList<>();
     private static final Random random = new Random();
@@ -183,7 +187,7 @@ public class NanopubUtils {
         try {
             NanopubUtils.propagateToHandler(np, writer);
         } catch (RDFHandlerException ex) {
-            ex.printStackTrace();
+            logger.warn("Could not collect the prefixes used by nanopub {}; returning the {} found so far", np.getUri(), usedPrefixes.size(), ex);
             return usedPrefixes;
         }
         return usedPrefixes;

--- a/src/main/java/org/nanopub/RoCrateParser.java
+++ b/src/main/java/org/nanopub/RoCrateParser.java
@@ -2,8 +2,6 @@ package org.nanopub;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Statement;
@@ -24,6 +22,8 @@ import org.nanopub.vocabulary.FDOF;
 import org.nanopub.vocabulary.KPXL;
 import org.nanopub.vocabulary.NPX;
 import org.nanopub.vocabulary.SCHEMA;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
  */
 public class RoCrateParser {
 
-    private static final Log LOG = LogFactory.getLog(RoCrateParser.class);
+    private static final Logger logger = LoggerFactory.getLogger(RoCrateParser.class);
     private static final ValueFactory vf = SimpleValueFactory.getInstance();
     static final String BASE_ROCRATE_API_URL = "https://api.rohub.org/api/ros/";
 
@@ -128,21 +128,16 @@ public class RoCrateParser {
                 Matcher m = p.matcher(url);
                 if (m.matches()) {
                     String resultingUrl = m.group(1);
-                    if (LOG.isDebugEnabled()) {
-                        try {
-                            String filename = m.group(2);
-                            if (filename.equals("ro-crate-metadata.json") || filename.equals("ro-crate-metadata.jsonld")) {
-                                // standard case, no logging
-                            } else {
-                                LOG.debug("Unexpected filename for RO-Create Metadata: " + filename);
-                                LOG.debug("Stripping the filename anyway and use '" + resultingUrl + "' as RO-Crate base.");
-                            }
-                        } catch (IllegalStateException | IndexOutOfBoundsException e) {
-                            // there was no trailing filename, all good
+                    try {
+                        String filename = m.group(2);
+                        if (!filename.equals("ro-crate-metadata.json") && !filename.equals("ro-crate-metadata.jsonld")) {
+                            logger.debug("Unexpected filename for RO-Crate metadata: {}; stripping it and using {} as RO-Crate base", filename, resultingUrl);
                         }
+                    } catch (IllegalStateException | IndexOutOfBoundsException ex) {
+                        logger.trace("No trailing filename in {}; using {} as RO-Crate base", url, resultingUrl, ex);
                     }
                     if (resultingUrl == null) {
-                        LOG.warn("Could not determine RO-Crate base URL with input url: " + url);
+                        logger.warn("Could not determine RO-Crate base URL from input url: {}", url);
                     }
                     return vf.createIRI(resultingUrl);
                 }
@@ -162,8 +157,8 @@ public class RoCrateParser {
                 .filter(st -> st.getPredicate().equals(SCHEMA.NAME))
                 .collect(Collectors.toSet());
         if (nameCandidates.size() != 1) {
-            LOG.info(String.format("This RO-Crate has an invalid number (%d) of names: %s", nameCandidates.size(), subj.stringValue()));
-            nameCandidates.stream().forEach(possibleName -> LOG.debug(possibleName.toString()));
+            logger.warn("RO-Crate {} has an invalid number ({}) of names; falling back to another label source", subj.stringValue(), nameCandidates.size());
+            nameCandidates.forEach(possibleName -> logger.debug("Name candidate: {}", possibleName));
         }
 
         String name;

--- a/src/main/java/org/nanopub/extra/security/SignNanopub.java
+++ b/src/main/java/org/nanopub/extra/security/SignNanopub.java
@@ -10,6 +10,8 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.*;
 import org.nanopub.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -26,6 +28,8 @@ import java.util.zip.GZIPOutputStream;
  * Command line tool to sign nanopubs with a private key.
  */
 public class SignNanopub extends CliRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(SignNanopub.class);
 
     @com.beust.jcommander.Parameter(description = "input-nanopub-files", required = true)
     private List<File> inputNanopubFiles = new ArrayList<>();
@@ -187,10 +191,12 @@ public class SignNanopub extends CliRunner {
             }
         }
         try {
-            return SignatureUtils.createSignedNanopub(nanopub, c);
+            Nanopub signed = SignatureUtils.createSignedNanopub(nanopub, c);
+            logger.debug("Signed nanopub {} as {}", nanopub.getUri(), signed.getUri());
+            return signed;
         } catch (Exception ex) {
-            ex.printStackTrace();
-            throw new RuntimeException(ex);
+            // Not logged here: the cause travels with the exception and is the caller's to report.
+            throw new RuntimeException("Could not sign nanopub " + nanopub.getUri(), ex);
         }
     }
 

--- a/src/main/java/org/nanopub/extra/security/SignatureUtils.java
+++ b/src/main/java/org/nanopub/extra/security/SignatureUtils.java
@@ -119,12 +119,15 @@ public class SignatureUtils {
         PublicKey publicKey = KeyFactory.getInstance(se.getAlgorithm().name()).generatePublic(publicSpec);
         signature.initVerify(publicKey);
 
-//		System.err.println("SIGNATURE INPUT: ---");
-//		System.err.print(RdfHasher.getDigestString(statements));
-//		System.err.println("---");
+        String digestString = RdfHasher.getDigestString(statements);
+        if (logger.isTraceEnabled()) {
+            logger.trace("Signature input for {}:\n{}", se.getTargetNanopubUri(), digestString);
+        }
 
-        signature.update(RdfHasher.getDigestString(statements).getBytes());
-        return signature.verify(se.getSignature());
+        signature.update(digestString.getBytes());
+        boolean valid = signature.verify(se.getSignature());
+        logger.debug("Signature of nanopub {} is {}", se.getTargetNanopubUri(), valid ? "valid" : "INVALID");
+        return valid;
     }
 
     /**
@@ -341,7 +344,9 @@ public class SignatureUtils {
                 return signatureElement.getPublicKeyString();
             }
         } catch (MalformedCryptoElementException | GeneralSecurityException ex) {
-            logger.error("Error in checking the signature of the nanopub {}", nanopub.getUri());
+            // Returning null is a normal outcome here, so this is not an error for the caller.
+            logger.warn("Could not check the signature of nanopub {}; treating it as unsigned: {}", nanopub.getUri(), ex.getMessage());
+            logger.debug("Signature check of nanopub {} failed", nanopub.getUri(), ex);
         }
         return null;
     }

--- a/src/main/java/org/nanopub/extra/server/FetchIndex.java
+++ b/src/main/java/org/nanopub/extra/server/FetchIndex.java
@@ -11,6 +11,8 @@ import org.nanopub.NanopubUtils;
 import org.nanopub.extra.index.IndexUtils;
 import org.nanopub.extra.index.NanopubIndex;
 import org.nanopub.extra.server.RegistryInfo.RegistryInfoException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.OutputStream;
 import java.util.*;
@@ -19,6 +21,8 @@ import java.util.*;
  * Fetches index.
  */
 public class FetchIndex {
+
+    private static final Logger logger = LoggerFactory.getLogger(FetchIndex.class);
 
     /**
      * The maximum number of parallel requests that can be made to a single server.
@@ -73,6 +77,7 @@ public class FetchIndex {
         try {
             ServerIterator.writeCachedServers(registries);
         } catch (Exception ex) {
+            logger.warn("Could not cache the registry list; it will be rebuilt on the next run", ex);
         }
         if (localRegistryUrl != null) {
             try {
@@ -81,7 +86,7 @@ public class FetchIndex {
                 serverLoad.put(localRegistryInfo, new HashSet<>());
                 serverUsage.put(localRegistryInfo, 0);
             } catch (RegistryInfoException ex) {
-                ex.printStackTrace();
+                logger.error("Could not load the local registry {}; aborting index fetch", localRegistryUrl, ex);
                 return;
             }
         }
@@ -103,6 +108,9 @@ public class FetchIndex {
             try {
                 Thread.sleep(5);
             } catch (InterruptedException ex) {
+                logger.debug("Interrupted while fetching index; stopping", ex);
+                Thread.currentThread().interrupt();
+                return;
             }
         }
     }
@@ -122,7 +130,7 @@ public class FetchIndex {
             }
             if (task.getNanopub() == null) {
                 if (task.getTriedServersCount() == registries.size()) {
-                    System.err.println("Failed to get " + task.getNanopubUri());
+                    logger.warn("Failed to get {} from any of the {} known registries; giving up on it", task.getNanopubUri(), registries.size());
                     fetchTasks.remove(task);
                     continue;
                 }

--- a/src/main/java/org/nanopub/extra/server/GetNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/GetNanopub.java
@@ -13,6 +13,8 @@ import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.Rio;
 import org.nanopub.*;
 import org.nanopub.trusty.TrustyNanopubUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -25,6 +27,8 @@ import static org.nanopub.extra.server.NanopubStatus.extractArtifactCode;
  * Command line tool to retrieve nanopubs from the server.
  */
 public class GetNanopub extends CliRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(GetNanopub.class);
 
     @com.beust.jcommander.Parameter(description = "nanopub-uris-or-artifact-codes", required = true)
     private List<String> nanopubIds;
@@ -138,9 +142,10 @@ public class GetNanopub extends CliRunner {
                     return np;
                 }
             } catch (IOException | MalformedNanopubException | RDF4JException ex) {
-                // ignore
+                logger.debug("Could not get {} from registry {}; trying the next one", ac, registryInfo.getUrl(), ex);
             }
         }
+        logger.warn("Could not get {} from any of the available registries", ac);
         return null;
     }
 

--- a/src/main/java/org/nanopub/extra/server/NanopubDb.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubDb.java
@@ -33,7 +33,7 @@ public class NanopubDb {
      * @param mongoDbPw       the password for MongoDB authentication (can be null)
      */
     public NanopubDb(String mongoDbHost, int mongoDbPort, String mongoDbName, String mongoDbUsername, String mongoDbPw) {
-        logger.info("Initialize new DB object");
+        logger.debug("Initializing nanopub DB for mongodb://{}:{}/{}", mongoDbHost, mongoDbPort, mongoDbName);
         ServerAddress serverAddress = new ServerAddress(mongoDbHost, mongoDbPort);
 
         if (mongoDbUsername != null) {

--- a/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
@@ -14,6 +14,8 @@ import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
 import org.nanopub.vocabulary.NTEMPLATE;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -21,6 +23,9 @@ import java.util.*;
  * Verifies if a technically fine nanopublication meets some standards or best practices.
  */
 public class NanopubVerifier {
+
+    private static final Logger logger = LoggerFactory.getLogger(NanopubVerifier.class);
+
     private final List<String> issues = new ArrayList<>();
     private final Nanopub nanopub;
 
@@ -47,6 +52,11 @@ public class NanopubVerifier {
         checkUriProtocol();
         checkLiteralDatatypes();
 
+        if (issues.isEmpty()) {
+            logger.debug("Nanopub {} passed verification with no issues", nanopub.getUri());
+        } else {
+            logger.debug("Nanopub {} has {} verification issue(s): {}", nanopub.getUri(), issues.size(), issues);
+        }
         return issues.isEmpty();
     }
 
@@ -219,6 +229,8 @@ public class NanopubVerifier {
                 }
             }
         } catch (MalformedCryptoElementException e) {
+            // Reported to the caller as a missing signature element; the actual cause is only visible here.
+            logger.debug("Signature element of nanopub {} is malformed: {}", nanopub.getUri(), e.getMessage(), e);
             issues.add("Nanopub has no signature element.");
         }
     }

--- a/src/main/java/org/nanopub/extra/server/PublishNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/PublishNanopub.java
@@ -3,8 +3,6 @@ package org.nanopub.extra.server;
 import com.beust.jcommander.ParameterException;
 import net.trustyuri.ArtifactCode;
 import net.trustyuri.TrustyUriUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -14,6 +12,8 @@ import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.nanopub.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class PublishNanopub extends CliRunner {
 
-    private static final Log LOG = LogFactory.getLog(PublishNanopub.class);
+    private static final Logger logger = LoggerFactory.getLogger(PublishNanopub.class);
 
     @com.beust.jcommander.Parameter(description = "nanopubs", required = true)
     private List<String> nanopubs = new ArrayList<>();
@@ -118,26 +118,32 @@ public class PublishNanopub extends CliRunner {
      */
     public PublishNanopub() {
         super();
-        initLogging();
     }
 
+    /**
+     * No-op retained for backwards compatibility.
+     *
+     * @deprecated This used to reconfigure the JVM-wide logging backend, which is not something a
+     * library may do to its host application. Progress detail is now emitted through SLF4J at DEBUG
+     * level, and additionally to standard error when the {@code -v} command line flag is given.
+     * Configure your logging backend instead of calling this method.
+     */
+    @Deprecated(forRemoval = true)
+    public void initLogging() {
+        // Intentionally empty: see deprecation notice.
+    }
 
     /**
-     * Little hack: We interpret an enabled DEBUG Log like the command line flag "verbose".
-     * The other way around, we do interpret the command line concept of setting the verbose flag as
-     * activation of debug log.
+     * Reports progress detail that is useful when running interactively but must stay out of an
+     * embedding application's output. On the command line ({@code -v}) it goes to standard error, so
+     * that standard output remains usable for piping; otherwise it is logged at DEBUG level.
      */
-    // TODO Push-Up! This will be useful with other CliTasks that support the verbose flag.
-    public void initLogging() {
-        if (LOG.isDebugEnabled()) {
-            verbose = true;
-        } else if (verbose) {
-            logOrSysout(LOG, "Enabling DEBUG log, since VERBOSE cli flag is enabled.");
-            if (!LOG.isTraceEnabled()) {
-                LogFactory.getFactory().setAttribute(LogFactory.PRIORITY_KEY, "DEBUG");
-            }
+    private void reportProgress(String message) {
+        if (verbose) {
+            System.err.println(message);
+        } else {
+            logger.debug(message);
         }
-        logOrSysout(LOG, "Initialized logging for CLI Runner. Verbose mode: " + verbose);
     }
 
 
@@ -153,9 +159,7 @@ public class PublishNanopub extends CliRunner {
                     }
                     processNanopub(new NanopubImpl(sparqlRepo, SimpleValueFactory.getInstance().createIRI(s)));
                 } else {
-                    if (verbose) {
-                        logOrSysout(LOG, "Reading file: " + s);
-                    }
+                    reportProgress("Reading file: " + s);
                     MultiNanopubRdfHandler.process(new File(s), np -> {
                         if (failed) {
                             return;
@@ -163,35 +167,35 @@ public class PublishNanopub extends CliRunner {
                         processNanopub(np);
                     });
                     if (count == 0) {
-                        String msg = "NO NANOPUB FOUND: " + s;
-                        LOG.info(msg);
-                        System.out.println(msg);
+                        logger.warn("No nanopub found in {}", s);
+                        System.out.println("NO NANOPUB FOUND: " + s);
                         break;
                     }
                 }
             } catch (RDF4JException ex) {
-                logOrSysout(LOG, "RDF ERROR: " + s);
-                ex.printStackTrace(System.err);
+                logger.error("Could not read RDF from {}", s, ex);
+                System.err.println("RDF ERROR: " + s);
                 break;
             } catch (MalformedNanopubException ex) {
-                logOrSysout(LOG, "INVALID NANOPUB: " + s);
-                ex.printStackTrace(System.err);
+                logger.error("Malformed nanopub in {}", s, ex);
+                System.err.println("INVALID NANOPUB: " + s);
                 break;
             }
             if (failed) {
-                logOrSysout(LOG, "FAILED TO PUBLISH NANOPUBS");
+                logger.error("Failed to publish nanopubs from {}", s);
+                System.err.println("FAILED TO PUBLISH NANOPUBS");
                 break;
             }
         }
         for (String s : usedServers.keySet()) {
             int c = usedServers.get(s);
-            logOrSysout(LOG, c + " nanopub" + (c == 1 ? "" : "s") + " published at " + s);
+            System.out.println(c + " nanopub" + (c == 1 ? "" : "s") + " published at " + s);
         }
         if (sparqlRepo != null) {
             try {
                 sparqlRepo.shutDown();
             } catch (RepositoryException ex) {
-                ex.printStackTrace();
+                logger.warn("Failed to shut down SPARQL repository {}", sparqlEndpointUrl, ex);
             }
         }
     }
@@ -204,6 +208,7 @@ public class PublishNanopub extends CliRunner {
         try {
             publishNanopub(nanopub);
         } catch (IOException ex) {
+            logger.error("Failed to publish nanopub {}", nanopub.getUri(), ex);
             if (verbose) {
                 System.err.println(ex.getClass().getName() + ": " + ex.getMessage());
                 System.err.println("---");
@@ -232,20 +237,13 @@ public class PublishNanopub extends CliRunner {
      * @throws java.io.IOException if an error occurs during publishing
      */
     public String publishNanopub(Nanopub nanopub, String serverUrl) throws IOException {
-        if (LOG.isDebugEnabled()) {
-            // Little hack: We interpret an enabled DEBUG Log like the command line flag "verbose".
-            // The other way around, we do interpret the command line concept of setting the verbose flag as
-            // activation of debug log.
-            verbose = true;
-        }
-
         NanopubVerifier verifier = new NanopubVerifier(nanopub);
         if (verifier.verify()) {
-            logOrSysout(LOG,"Verification of Nanopub done, no issues.");
+            logger.debug("Verification of nanopub {} done, no issues", nanopub.getUri());
         } else {
-            logOrSysout(LOG,"Verification of Nanopub shows some issues: " + verifier.getIssues());
+            logger.warn("Verification of nanopub {} shows some issues: {}", nanopub.getUri(), verifier.getIssues());
             if (strict) {
-                logOrSysout(LOG,"Strict mode. Nanopub is not published");
+                logger.warn("Strict mode: nanopub {} is not published", nanopub.getUri());
                 return null;
             }
         }
@@ -261,9 +259,7 @@ public class PublishNanopub extends CliRunner {
             registryInfo = serverIterator.next();
         }
         artifactCode = ArtifactCode.of(TrustyUriUtils.getArtifactCode(nanopub.getUri().toString()));
-        if (verbose) {
-            logOrSysout(LOG, "Trying to publish nanopub: " + artifactCode);
-        }
+        reportProgress("Trying to publish nanopub: " + artifactCode);
         if (NanopubServerUtils.isProtectedNanopub(nanopub)) {
             throw new RuntimeException("Can't publish protected nanopublication: " + artifactCode);
         }
@@ -272,9 +268,7 @@ public class PublishNanopub extends CliRunner {
 
             // TODO Check here whether nanopub type is covered at given registry.
 
-            if (verbose) {
-                logOrSysout(LOG, "Trying server: " + url);
-            }
+            reportProgress("Trying server: " + url);
             try {
                 HttpPost post = preparePost(nanopub);
                 if (!dryRun) {
@@ -284,9 +278,9 @@ public class PublishNanopub extends CliRunner {
                     }
                 }
             } catch (IOException | RDF4JException ex) {
-                if (verbose) {
-                    logOrSysout(LOG, ex.getClass().getName() + ": " + ex.getMessage());
-                }
+                logger.warn("Publishing {} to {} failed, trying next registry — {}: {}", artifactCode, url, ex.getClass().getSimpleName(), ex.getMessage());
+                logger.debug("Publishing {} to {} failed", artifactCode, url, ex);
+                reportProgress(ex.getClass().getName() + ": " + ex.getMessage());
             }
             registryInfo = serverIterator.next();
         }
@@ -319,14 +313,12 @@ public class PublishNanopub extends CliRunner {
                 usedServers.put(url, 1);
             }
             String nanopubUrl = registryInfo.getCollectionUrl() + artifactCode;
-            if (verbose) {
-                logOrSysout(LOG, "Published: " + nanopubUrl);
-            }
+            logger.debug("Published {} at {}", artifactCode, nanopubUrl);
+            reportProgress("Published: " + nanopubUrl);
             return nanopubUrl;
         } else {
-            if (verbose) {
-                logOrSysout(LOG, "Response: " + code + " " + response.getStatusLine().getReasonPhrase());
-            }
+            logger.warn("Registry {} rejected {} with HTTP {} {}", url, artifactCode, code, response.getStatusLine().getReasonPhrase());
+            reportProgress("Response: " + code + " " + response.getStatusLine().getReasonPhrase());
         }
         return null; // post failed
     }

--- a/src/main/java/org/nanopub/extra/server/ServerIterator.java
+++ b/src/main/java/org/nanopub/extra/server/ServerIterator.java
@@ -1,6 +1,8 @@
 package org.nanopub.extra.server;
 
 import org.nanopub.extra.server.RegistryInfo.RegistryInfoException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.*;
@@ -9,6 +11,8 @@ import java.util.*;
  * An iterator that provides access to a list of nanopub servers.
  */
 public class ServerIterator implements Iterator<RegistryInfo> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServerIterator.class);
 
     private static Map<String, RegistryInfo> serverInfos = new HashMap<>();
     private static long serverInfoRefreshed = System.currentTimeMillis();
@@ -36,6 +40,7 @@ public class ServerIterator implements Iterator<RegistryInfo> {
             try {
                 loadCachedServers();
             } catch (Exception ex) {
+                logger.warn("Could not read the cached registry list from {}; falling back to the bootstrap list", getServerListFile(), ex);
             }
         }
         if (cachedServers == null) {
@@ -135,7 +140,8 @@ public class ServerIterator implements Iterator<RegistryInfo> {
                 }
                 serverInfos.put(url, info);
             } catch (RegistryInfoException ex) {
-                // ignore
+                logger.warn("Could not load registry info from {}; skipping this registry: {}", url, ex.getMessage());
+                logger.debug("Registry info request to {} failed", url, ex);
             }
         }
         return serverInfos.get(url);

--- a/src/main/java/org/nanopub/extra/server/UnreliableInputStream.java
+++ b/src/main/java/org/nanopub/extra/server/UnreliableInputStream.java
@@ -35,6 +35,7 @@ public class UnreliableInputStream extends InputStream {
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
             }
             throw new SimulatedIOException("Simulated IO Problem");
         }
@@ -55,6 +56,7 @@ public class UnreliableInputStream extends InputStream {
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
             }
             throw new SimulatedIOException("Simulated IO Problem");
         }
@@ -76,6 +78,7 @@ public class UnreliableInputStream extends InputStream {
             try {
                 Thread.sleep(5000);
             } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
             }
             throw new SimulatedIOException("Simulated IO Problem");
         }

--- a/src/main/java/org/nanopub/extra/services/QueryCall.java
+++ b/src/main/java/org/nanopub/extra/services/QueryCall.java
@@ -222,7 +222,7 @@ public class QueryCall {
                 continue;
             }
             try {
-                logger.info("Checking API instance: {}", a);
+                logger.debug("Checking API instance: {}", a);
                 HttpResponse resp = NanopubUtils.getHttpClient().execute(new HttpGet(a));
                 if (!wasSuccessful(resp)) {
                     EntityUtils.consumeQuietly(resp.getEntity());
@@ -236,12 +236,13 @@ public class QueryCall {
                     evict(a, "status " + status);
                 } else {
                     EntityUtils.consumeQuietly(resp.getEntity());
-                    logger.info("Nanopub Query instance admitted: {}", a);
+                    logger.debug("Nanopub Query instance admitted: {}", a);
                     checkedApiInstances.add(a);
                     anyNewAdmitted = true;
                 }
             } catch (IOException ex) {
                 logger.warn("Nanopub Query instance not accessible ({}): {}", ex.getMessage(), a);
+                logger.debug("Health check request to {} failed", a, ex);
                 evict(a, "not accessible");
             }
         }
@@ -265,11 +266,11 @@ public class QueryCall {
         if (override != null && !override.trim().isEmpty()) {
             List<String> list = new ArrayList<>();
             for (String url : override.trim().split("\\s+")) list.add(url);
-            logger.info("Using {} query API instance(s) from override", list.size());
+            logger.debug("Using {} query API instance(s) from override", list.size());
             return list;
         }
         List<String> fromSetting = ServiceLookup.getServices(NPS.NANOPUB_QUERY_1_1);
-        logger.info("Discovered {} query API instance(s) from setting", fromSetting.size());
+        logger.debug("Discovered {} query API instance(s) from setting", fromSetting.size());
         return new ArrayList<>(fromSetting);
     }
 
@@ -297,7 +298,7 @@ public class QueryCall {
             int randomIndex = (int) ((Math.random() * apiInstancesToTry.size()));
             String apiUrl = apiInstancesToTry.get(randomIndex);
             apisToCall.add(apiUrl);
-            logger.info("Dispatching to instance {}/{}: {}", apisToCall.size(), parallelCallCount, apiUrl);
+            logger.debug("Dispatching to instance {}/{}: {}", apisToCall.size(), parallelCallCount, apiUrl);
             apiInstancesToTry.remove(randomIndex);
         }
         for (String api : apisToCall) {
@@ -314,7 +315,7 @@ public class QueryCall {
         }
         long len = resp.getEntity().getContentLength();
         String sizeStr = len >= 0 ? len + " bytes" : "unknown (chunked/no Content-Length)";
-        logger.info("Response received from {} for query {} ({})", apiUrl, queryRef, sizeStr);
+        logger.debug("Response received from {} for query {} ({})", apiUrl, queryRef, sizeStr);
         this.resp = resp;
 
         for (Call c : calls) {
@@ -375,6 +376,7 @@ public class QueryCall {
                     EntityUtils.consumeQuietly(resp.getEntity());
                 }
                 logger.warn("Request to {} failed for query {} — {}: {}", apiUrl, queryRef, ex.getClass().getSimpleName(), ex.getMessage());
+                logger.debug("Request to {} failed for query {}", apiUrl, queryRef, ex);
             }
             calls.remove(this);
         }

--- a/src/main/java/org/nanopub/extra/services/ServiceLookup.java
+++ b/src/main/java/org/nanopub/extra/services/ServiceLookup.java
@@ -73,6 +73,7 @@ public class ServiceLookup {
                     if (url != null) urls.add(url);
                 } catch (Exception ex) {
                     logger.warn("Failed to process service intro {}: {}", elementIri, ex.getMessage());
+                    logger.debug("Failed to process service intro {}", elementIri, ex);
                 }
             }
         } catch (Exception ex) {

--- a/src/main/java/org/nanopub/extra/setting/IntroNanopub.java
+++ b/src/main/java/org/nanopub/extra/setting/IntroNanopub.java
@@ -22,6 +22,8 @@ import org.nanopub.extra.security.KeyDeclaration;
 import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.server.GetNanopub;
 import org.nanopub.vocabulary.NPX;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,6 +37,8 @@ import java.util.Map;
  * This class represents an Intro Nanopub, which is a nanopublication that contains the introduction of a user.
  */
 public class IntroNanopub implements Serializable {
+
+    private static final Logger logger = LoggerFactory.getLogger(IntroNanopub.class);
 
     /**
      * Get the IntroNanopub for a userId.
@@ -168,13 +172,13 @@ public class IntroNanopub implements Serializable {
                     try {
                         d.setAlgorithm((Literal) obj);
                     } catch (MalformedCryptoElementException ex) {
-                        //ex.printStackTrace();
+                        logger.warn("Ignoring malformed algorithm {} in key declaration {}: {}", obj, subj, ex.getMessage());
                     }
                 } else if (pred.equals(NPX.HAS_PUBLIC_KEY) && obj instanceof Literal) {
                     try {
                         d.setPublicKeyLiteral((Literal) obj);
                     } catch (MalformedCryptoElementException ex) {
-                        //ex.printStackTrace();
+                        logger.warn("Ignoring malformed public key in key declaration {}: {}", subj, ex.getMessage());
                     }
                 }
             }

--- a/src/main/java/org/nanopub/fdo/ValidateFdo.java
+++ b/src/main/java/org/nanopub/fdo/ValidateFdo.java
@@ -11,6 +11,8 @@ import org.eclipse.rdf4j.model.vocabulary.SHACL;
 import org.nanopub.fdo.rest.gson.ParsedSchemaResponse;
 import org.nanopub.vocabulary.FDOF;
 import org.nanopub.vocabulary.HDL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
@@ -31,6 +33,8 @@ import static org.nanopub.fdo.FdoUtils.*;
 // TODO class that provides the Op.Validate operations.
 //      See https://fdo-connect.gitlab.io/ap1/architecture-documentation/main/operation-specification/
 public class ValidateFdo {
+
+    private static final Logger logger = LoggerFactory.getLogger(ValidateFdo.class);
 
     private static final ValueFactory vf = SimpleValueFactory.getInstance();
 
@@ -62,8 +66,7 @@ public class ValidateFdo {
         Set<Statement> shaclShape = createShaclValidationShapeFromJson(httpResponse);
         Set<Statement> data = addTypeStatement(fdoRecord);
 
-        System.out.println("Validating FdoRecord " + fdoRecord.getId());
-        System.out.println("Against Schema " + schemaUrl);
+        logger.debug("Validating FDO record {} against schema {}", fdoRecord.getId(), schemaUrl);
 
         return ShaclValidator.validateShacl(shaclShape, data);
     }

--- a/src/main/java/org/nanopub/trusty/MakeTrustyNanopub.java
+++ b/src/main/java/org/nanopub/trusty/MakeTrustyNanopub.java
@@ -10,6 +10,8 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.rio.*;
 import org.nanopub.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -20,6 +22,8 @@ import java.util.zip.GZIPOutputStream;
  * Command-line tool to transform nanopubs into Trusty Nanopubs.
  */
 public class MakeTrustyNanopub extends CliRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(MakeTrustyNanopub.class);
 
     @com.beust.jcommander.Parameter(description = "input-nanopub-files", required = true)
     private List<File> inputNanopubsFiles = new ArrayList<>();
@@ -169,6 +173,7 @@ public class MakeTrustyNanopub extends CliRunner {
         if (np instanceof NanopubWithNs) {
             ((NanopubWithNs) np).removeUnusedPrefixes();
         }
+        logger.debug("Transformed nanopub {} into trusty nanopub {}", nanopub.getUri(), np.getUri());
         return np;
     }
 

--- a/src/main/java/org/nanopub/trusty/TrustyNanopubUtils.java
+++ b/src/main/java/org/nanopub/trusty/TrustyNanopubUtils.java
@@ -17,6 +17,8 @@ import org.nanopub.NanopubUtils;
 import org.nanopub.vocabulary.NP;
 import org.nanopub.vocabulary.PAV;
 import org.nanopub.vocabulary.RDFG;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -29,6 +31,8 @@ import java.util.Set;
  * Utility class for handling Trusty Nanopubs.
  */
 public class TrustyNanopubUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(TrustyNanopubUtils.class);
 
     /**
      * The RDF format for serialized Trusty Nanopubs.
@@ -89,23 +93,29 @@ public class TrustyNanopubUtils {
         IRI nanopubUri = nanopub.getUri();
         for (IRI uri : graphUris) {
             if (!uri.stringValue().startsWith(nanopubUri.stringValue())) {
+                logger.debug("Nanopub {} is not trusty: graph URI {} is not under the nanopub URI", nanopubUri, uri);
                 return false;
             }
         }
 
         String artifactCode = TrustyUriUtils.getArtifactCode(nanopub.getUri().toString());
         if (artifactCode == null) {
+            logger.debug("Nanopub {} is not trusty: its URI carries no artifact code", nanopubUri);
             return false;
         }
         List<Statement> statements = NanopubUtils.getStatements(nanopub);
         statements = RdfPreprocessor.run(statements, artifactCode);
 
-//		System.err.println("TRUSTY INPUT: ---");
-//		System.err.print(RdfHasher.getDigestString(statements));
-//		System.err.println("---");
+        if (logger.isTraceEnabled()) {
+            logger.trace("Trusty input for {}:\n{}", nanopubUri, RdfHasher.getDigestString(statements));
+        }
 
         ArtifactCode ac = RdfHasher.makeArtifactCode(statements);
-        return ac.toString().equals(artifactCode);
+        if (!ac.toString().equals(artifactCode)) {
+            logger.debug("Nanopub {} is not trusty: artifact code in the URI is {} but the content hashes to {}", nanopubUri, artifactCode, ac);
+            return false;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Why

This library is consumed both as a Maven dependency and as a CLI, and its logging did not distinguish the two. Library code wrote to stdout, swallowed exceptions, and reconfigured the host application's logging backend.

Before this change, only 5 of 169 classes in `src/main` had a logger, and the 32 log statements were concentrated in three recently-added files — the core parsing, trusty-URI, signing and indexing paths had none.

## What changed

**Unify on SLF4J.** All use of Apache commons-logging is gone (`CliRunner`, `PublishNanopub`, `RoCrateParser`). Both `commons-logging` and `jcl-over-slf4j` are on the classpath transitively and each ships `org/apache/commons/logging/LogFactory.class`, so which one served these classes was classpath-order dependent.

`PublishNanopub.initLogging()` no longer calls `LogFactory.setAttribute(PRIORITY_KEY, "DEBUG")`, which reconfigured logging JVM-wide from inside a `--verbose` flag handler. It is kept as a deprecated no-op. It is also no longer called from the constructor, where it printed `Initialized logging for CLI Runner` to stdout on every instantiation — including from the static `publish()` helpers.

**Keep CLI output, drop library output.** Results stay on stdout in the CLI-only code paths so they remain pipeable. Progress detail goes to stderr under `-v` and to DEBUG otherwise, via a new private `reportProgress()`. `ValidateFdo` logs at DEBUG instead of printing to stdout.

**No more silent failures on the library path.** `src/main` now has no `printStackTrace()` outside CLI entry points and no empty catch blocks. `NanopubImpl`, `NanopubUtils`, `FetchIndex`, `ServerIterator`, `GetNanopub`, `IntroNanopub` and `HtmlWriter` now report what they caught and what they did about it. `UnreliableInputStream` restores the interrupt flag.

**Correct the levels, stop losing stack traces.** `QueryCall`'s per-request INFO messages become DEBUG — at INFO they flooded the logs of any consumer issuing queries in a loop. `SignatureUtils.getPubKey` drops from ERROR to WARN, since returning `null` is a documented outcome, and now passes the exception. Sites that logged only `ex.getMessage()` gained a companion DEBUG carrying the stack trace.

| level | before | after |
|---|---:|---:|
| trace | 0 | 3 |
| debug | 3 | 35 |
| info | 9 | 2 |
| warn | 17 | 34 |
| error | 3 | 8 |

**Extend coverage into the core paths.** `TrustyNanopubUtils` now reports which check made a nanopub non-trusty, including both artifact codes on a hash mismatch. `NanopubVerifier` logs its issue summary and the malformed-signature cause it otherwise discarded. `NanopubImpl`, `SignNanopub` and `MakeTrustyNanopub` log load, sign and transform outcomes. Classes with a logger go from 5 to 20; every call site uses `{}` placeholders.

## Compatibility

`CliRunner.logOrSysout`'s first parameter changes from `org.apache.commons.logging.Log` to `org.slf4j.Logger`. It is `protected static` and used only within the library when run as a CLI, so this is not treated as a breaking change and no `BREAKING CHANGE` footer is set. All 39 in-repo subclasses are updated.

No log message text that tests assert on was changed.

## Not in this PR

The published artifact still carries `slf4j-simple` as a `runtime` dependency and bundles `simplelogger.properties`, both of which reach consumers:

- The `cli` and `release` profiles share `env.CI` activation, so `slf4j-simple` is written into the POM deployed to Maven Central. Because profiles in a dependency POM are activated from the *consumer's* environment, any downstream project building with `CI` set inherits an SLF4J binding. Verified against released 1.91.0: `dependency:tree` shows `org.slf4j:slf4j-simple:2.0.18:runtime` with `CI=true` and not without it.
- `src/main/resources/simplelogger.properties` is packaged into the Maven artifact and sets `defaultLogLevel = warn`, which can override a consumer's own configuration.

Both are pom/packaging changes and are left for a follow-up.

## Testing

`./mvnw test` — 586 tests, 0 failures.
