### PR TITLE
chore(cli): install the CLI from Maven Central instead of the GitHub API

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master, main ]
     paths:
       - 'docs/**'
+      - 'bin/install.sh'
+      - 'bin/install.ps1'
       - 'mkdocs.yml'
       - 'pyproject.toml'
       - 'poetry.lock'
@@ -40,6 +42,11 @@ jobs:
 
       - name: Install the project dependencies
         run: poetry install
+
+      # Served as https://nanopublication.github.io/nanopub-java/install.{sh,ps1} so
+      # the install one-liners do not depend on raw.githubusercontent.com
+      - name: Stage the CLI installers for publishing
+        run: cp bin/install.sh bin/install.ps1 docs/
 
       - name: Deploy MkDocs on GitHub Pages
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 site/
 venv/
 node_modules/
+
+# Copied in from bin/ by the docs workflow at build time
+/docs/install.sh
+/docs/install.ps1

--- a/README.md
+++ b/README.md
@@ -75,15 +75,17 @@ To use this library on the command line, just run:
 
 macOS, Linux, WSL:
 ```bash
-curl -LsSf https://raw.githubusercontent.com/Nanopublication/nanopub-java/master/bin/install.sh | bash
+curl -LsSf https://nanopublication.github.io/nanopub-java/install.sh | bash
 ```
 Windows PowerShell:
 ```bash
-irm https://raw.githubusercontent.com/Nanopublication/nanopub-java/master/bin/install.ps1 | iex
+irm https://nanopublication.github.io/nanopub-java/install.ps1 | iex
 ```
 
 This automatically downloads the latest release as a jar file on the first run. If an old version is there, it updates 
-np to the newest release. 
+np to the newest release. The jar is fetched from [Maven
+Central](https://central.sonatype.com/artifact/org.nanopub/nanopub), so the installer is not subject to the GitHub API
+rate limit. Set `NANOPUB_VERSION` to install a specific version instead of the latest one.
 
 ## Usage with Docker
 

--- a/bin/install.ps1
+++ b/bin/install.ps1
@@ -1,9 +1,10 @@
 # Nanopub CLI installer for Windows (PowerShell)
-# Usage: irm https://raw.githubusercontent.com/Nanopublication/nanopub-java/master/bin/install.ps1 | iex
+# Usage: irm https://nanopublication.github.io/nanopub-java/install.ps1 | iex
 #
 # Optional environment variable overrides (set before running):
 #   $env:NANOPUB_INSTALL_DIR  — where the np.cmd launcher is placed (default: ~\.nanopub\bin)
 #   $env:NANOPUB_JAR_DIR      — where the jar file is saved       (default: ~\.nanopub\lib)
+#   $env:NANOPUB_VERSION      — install this version instead of the latest one
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -26,6 +27,10 @@ $InstallDir = if ($env:NANOPUB_INSTALL_DIR) { $env:NANOPUB_INSTALL_DIR } `
 $JarDir     = if ($env:NANOPUB_JAR_DIR)     { $env:NANOPUB_JAR_DIR }     `
               else { Join-Path $HOME '.nanopub\lib' }
 
+# Artifacts are fetched from Maven Central rather than the GitHub release API,
+# which is rate limited to 60 requests per hour per IP for anonymous callers.
+$MavenBase = 'https://repo1.maven.org/maven2/org/nanopub/nanopub'
+
 # ── Preflight checks ──────────────────────────────────────────────────────────
 
 Info "Checking prerequisites..."
@@ -40,31 +45,32 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
     Err "PowerShell 5 or later is required (you have $($PSVersionTable.PSVersion))."
 }
 
-# ── Resolve latest version + direct download URL via GitHub API ───────────────
+# Windows PowerShell 5.1 may still default to TLS 1.0, which Maven Central rejects
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-Info "Resolving latest nanopub release..."
+# ── Resolve version + download URL via Maven Central ──────────────────────────
 
-try {
-    $Release = Invoke-RestMethod `
-        -Uri 'https://api.github.com/repos/Nanopublication/nanopub-java/releases/latest' `
-        -Headers @{ Accept = 'application/vnd.github+json' }
-} catch {
-    Err "Could not reach GitHub API: $_`nCheck your internet connection."
+if ($env:NANOPUB_VERSION) {
+    $Version = $env:NANOPUB_VERSION
+    Info "Using pinned version: $Version"
+} else {
+    Info "Resolving latest nanopub release..."
+
+    try {
+        $Metadata = Invoke-RestMethod -Uri "$MavenBase/maven-metadata.xml"
+    } catch {
+        Err "Could not reach Maven Central: $_`nCheck your internet connection."
+    }
+
+    # <release> holds the newest non-snapshot version
+    $Version = $Metadata.metadata.versioning.release
+    if (-not $Version) { Err "Could not determine latest version from Maven Central metadata." }
+
+    Info "Latest version: $Version"
 }
 
-# tag_name is e.g. "nanopub-1.86.2" → strip the prefix
-$Version = $Release.tag_name -replace '^nanopub-', ''
-if (-not $Version) { Err "Could not determine latest version from GitHub API." }
-
-Info "Latest version: $Version"
-
 $JarName = "nanopub-${Version}-jar-with-dependencies.jar"
-
-# Find the direct browser_download_url for the jar asset
-$Asset = $Release.assets | Where-Object { $_.name -eq $JarName } | Select-Object -First 1
-if (-not $Asset) { Err "Could not find asset '$JarName' in the release. Check the releases page." }
-
-$JarUrl  = $Asset.browser_download_url
+$JarUrl  = "$MavenBase/$Version/$JarName"
 $JarPath = Join-Path $JarDir $JarName
 $TmpPath = "$JarPath.tmp"
 
@@ -90,7 +96,7 @@ if (Test-Path $JarPath) {
     $bytes = [System.IO.File]::ReadAllBytes($TmpPath)
     if ($bytes.Length -lt 2 -or $bytes[0] -ne 0x50 -or $bytes[1] -ne 0x4B) {
         Remove-Item -Force $TmpPath -ErrorAction SilentlyContinue
-        Err "Downloaded file is not a valid jar (bad magic bytes).`nThis usually means the download returned an HTML page instead of the binary.`nTry running the installer again, or download manually from:`n  $JarUrl"
+        Err "Downloaded file is not a valid jar (bad magic bytes).`nThis usually means a proxy returned an HTML page instead of the binary.`nTry running the installer again, or download manually from:`n  $JarUrl"
     }
 
     Move-Item -Path $TmpPath -Destination $JarPath
@@ -145,5 +151,6 @@ Write-Host ""
 Write-Host "    np check nanopubfile.trig"
 Write-Host ""
 Write-Host "  Tip: set `$env:NANOPUB_INSTALL_DIR or `$env:NANOPUB_JAR_DIR before"
-Write-Host "  running this script to customize installation paths."
+Write-Host "  running this script to customize installation paths, or"
+Write-Host "  `$env:NANOPUB_VERSION to install a specific version."
 Write-Host ""

--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # Nanopub CLI installer
-# Usage: curl -LsSf https://raw.githubusercontent.com/Nanopublication/nanopub-java/master/bin/install.sh | bash
+# Usage: curl -LsSf https://nanopublication.github.io/nanopub-java/install.sh | bash
 
 set -e
 
 INSTALL_DIR="${NANOPUB_INSTALL_DIR:-$HOME/.nanopub/bin}"
 JAR_DIR="${NANOPUB_JAR_DIR:-$HOME/.nanopub/lib}"
+
+# Artifacts are fetched from Maven Central rather than the GitHub release API,
+# which is rate limited to 60 requests per hour per IP for anonymous callers.
+MAVEN_BASE="https://repo1.maven.org/maven2/org/nanopub/nanopub"
 
 # ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -22,38 +26,31 @@ need_cmd() {
 need_cmd curl
 need_cmd java
 
-# ── Resolve latest version + direct download URL via GitHub API ───────────────
+# ── Resolve version + download URL via Maven Central ──────────────────────────
 
-info "Resolving latest nanopub release..."
+if [ -n "$NANOPUB_VERSION" ]; then
+  VERSION="$NANOPUB_VERSION"
+  info "Using pinned version: $VERSION"
+else
+  info "Resolving latest nanopub release..."
 
-# The GitHub API returns JSON with a browser_download_url that is the final,
-# redirect-free URL — avoids the BSD curl / multi-redirect issue on macOS.
-API_RESPONSE=$(
-  curl -fsSL \
-    -H "Accept: application/vnd.github+json" \
-    "https://api.github.com/repos/Nanopublication/nanopub-java/releases/latest"
-) || error "Could not reach GitHub API. Check your internet connection."
+  METADATA=$(curl -fsSL "$MAVEN_BASE/maven-metadata.xml") \
+    || error "Could not reach Maven Central. Check your internet connection."
 
-# Extract version from tag_name (e.g. "nanopub-1.86.2" → "1.86.2")
-VERSION=$(printf '%s' "$API_RESPONSE" \
-  | grep '"tag_name"' \
-  | head -1 \
-  | sed 's/.*"tag_name": *"nanopub-//;s/".*//')
+  # <release> holds the newest non-snapshot version
+  VERSION=$(printf '%s' "$METADATA" \
+    | tr '<' '\n' \
+    | grep '^release>' \
+    | head -1 \
+    | sed 's/^release>//')
 
-[ -z "$VERSION" ] && error "Could not determine latest version from GitHub API."
+  [ -z "$VERSION" ] && error "Could not determine latest version from Maven Central metadata."
 
-info "Latest version: $VERSION"
+  info "Latest version: $VERSION"
+fi
 
 JAR_NAME="nanopub-${VERSION}-jar-with-dependencies.jar"
-
-# Pull the browser_download_url for the jar asset directly — no redirects needed
-JAR_URL=$(printf '%s' "$API_RESPONSE" \
-  | grep '"browser_download_url"' \
-  | grep "$JAR_NAME" \
-  | head -1 \
-  | sed 's/.*"browser_download_url": *"//;s/".*//')
-
-[ -z "$JAR_URL" ] && error "Could not find download URL for $JAR_NAME in the release assets."
+JAR_URL="$MAVEN_BASE/$VERSION/$JAR_NAME"
 
 # ── Download jar ───────────────────────────────────────────────────────────────
 
@@ -76,7 +73,7 @@ else
   if [ "$MAGIC" != "504b" ]; then
     rm -f "$TMP_PATH"
     error "Downloaded file is not a valid jar (bad magic bytes: $MAGIC). \
-This usually means the download URL returned an HTML redirect page instead of the binary. \
+This usually means a proxy returned an HTML page instead of the binary. \
 Try running the installer again, or download manually from: $JAR_URL"
   fi
 
@@ -144,5 +141,6 @@ echo ""
 echo "    np check nanopubfile.trig"
 echo ""
 echo "  Tip: set NANOPUB_INSTALL_DIR or NANOPUB_JAR_DIR before running this"
-echo "  script to customize installation paths."
+echo "  script to customize installation paths, or NANOPUB_VERSION to install"
+echo "  a specific version instead of the latest one."
 echo ""

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -36,12 +36,24 @@ To use this library on the command line, just run:
 
 === "macOS, Linux, WSL"
     ``` bash
-    curl -LsSf https://raw.githubusercontent.com/Nanopublication/nanopub-java/master/bin/install.sh | bash
+    curl -LsSf https://nanopublication.github.io/nanopub-java/install.sh | bash
     ```
 
 === "Windows PowerShell"
     ``` bash
-    irm https://raw.githubusercontent.com/Nanopublication/nanopub-java/master/bin/install.ps1 | iex
+    irm https://nanopublication.github.io/nanopub-java/install.ps1 | iex
     ```
 
 This automatically downloads the latest release as a jar file on the first run.
+
+The jar is fetched from [Maven Central](https://central.sonatype.com/artifact/org.nanopub/nanopub).
+
+!!! tip "Environment variables"
+
+    Set these before running the installer to change its behaviour:
+
+    | Variable | Purpose |
+    | --- | --- |
+    | `NANOPUB_VERSION` | Install a specific version instead of the latest one |
+    | `NANOPUB_INSTALL_DIR` | Where the `np` launcher is placed (default: `~/.nanopub/bin`) |
+    | `NANOPUB_JAR_DIR` | Where the jar file is saved (default: `~/.nanopub/lib`) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ nav:
 
 theme:
   name: "material"
-  favicon: assets/icon.png
+  favicon: assets/nanopub-icon.svg
   logo: assets/nanopub-icon.svg
   # icon:
   #   logo: material/microscope


### PR DESCRIPTION
## Problem

The install one-liner in the README resolved the latest release through `api.github.com`, which is **rate limited to 60 requests per hour per IP** for anonymous callers:

```
$ curl -s https://api.github.com/rate_limit
"core": { "limit": 60, ... }
```

Shared networks, VPNs, university NATs, CI runners and Docker builds exhaust that quota easily, and the installer then dies at a misleading `Could not reach GitHub API. Check your internet connection.`

The bootstrap step had a second, softer dependency: the script itself was fetched from `raw.githubusercontent.com` at an unpinned `master` ref, a domain some corporate proxies block.

## Fix

**Resolve and download from Maven Central.** The `jar-with-dependencies` artifact is already published there, and `maven-metadata.xml` gives the latest version with no API and no rate limit. This also removes the GitHub multi-redirect workaround the old script was built around, since Central serves the binary directly.

**Serve the installers from the docs site.** The docs workflow now stages `bin/install.{sh,ps1}` into `docs/` before `mkdocs gh-deploy`, publishing them at `https://nanopublication.github.io/nanopub-java/install.sh`. Different CDN, no API quota, stable branded URL.

New install commands:

```bash
curl -LsSf https://nanopublication.github.io/nanopub-java/install.sh | bash   # macOS, Linux, WSL
irm https://nanopublication.github.io/nanopub-java/install.ps1 | iex          # Windows PowerShell
```

Both installers also gain `NANOPUB_VERSION` to pin a version and skip resolution entirely, and `install.ps1` now forces TLS 1.2, which Windows PowerShell 5.1 does not always default to.

## Commits

- `chore(cli)` — installer scripts, docs workflow staging step, gitignore
- `docs(cli)` — README and setup page
- `docs` — unrelated one-liner: `theme.favicon` pointed at `assets/icon.png`, which does not exist and 404s on the live site. Drop this commit if you would rather keep the branch focused.

## Testing

`install.sh` was run end to end against a throwaway `$HOME`: resolved 1.91.0, downloaded the 27 MB jar from Central, wrote the launcher, and `np` ran and reported `nanopub-java version: 1.91.0`. `NANOPUB_VERSION=1.90.0` installed that version instead; `NANOPUB_VERSION=9.9.9` failed cleanly on the 404 with no partial jar left behind.

Two things could not be executed locally:

- **`install.ps1` is unrun** — no `pwsh` available. The logic mirrors the shell version; Central serves the metadata as `content-type: text/xml`, so `Invoke-RestMethod` returns an `XmlDocument` and `$Metadata.metadata.versioning.release` resolves rather than returning a string.
- **The mkdocs build is unrun** — the local poetry venv is broken and the pyenv mkdocs lacks the `material` theme. The mechanism is confirmed from the live site, which already serves `docs/assets/nanopub-icon.svg` verbatim.

## Note before merging

The new URLs 404 until this lands on `master` and the docs workflow deploys. Both `bin/install.sh` and `docs.yml` are in that workflow's trigger paths, so the merge itself fires it — but do not publicise the one-liner before that run goes green.

Also worth a decision: `chore` and `docs` are both non-releasing types under the conventional-commits preset, so this reaches users only when a later `fix`/`feat` cuts a release. Retitle the first commit `fix(cli)` if you want it to ship on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
