### PR TITLE
Make the op command-line tools testable, and test them

### DIFF
--- a/src/main/java/org/nanopub/op/Aggregate.java
+++ b/src/main/java/org/nanopub/op/Aggregate.java
@@ -46,14 +46,27 @@ public class Aggregate extends CliRunner {
      * @param args Command line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Aggregate obj = CliRunner.initJc(new Aggregate(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Aggregate.java
+++ b/src/main/java/org/nanopub/op/Aggregate.java
@@ -46,8 +46,7 @@ public class Aggregate extends CliRunner {
      * @param args Command line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -58,16 +57,7 @@ public class Aggregate extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Aggregate obj = CliRunner.initJc(new Aggregate(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Aggregate(), args).run());
     }
 
     /**

--- a/src/main/java/org/nanopub/op/Build.java
+++ b/src/main/java/org/nanopub/op/Build.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.rdf4j.model.IRI;
@@ -48,8 +47,7 @@ public class Build extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -60,16 +58,7 @@ public class Build extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Build obj = CliRunner.initJc(new Build(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Build(), args).run());
     }
 
     private RDFFormat rdfInFormat, rdfOutFormat;

--- a/src/main/java/org/nanopub/op/Build.java
+++ b/src/main/java/org/nanopub/op/Build.java
@@ -48,14 +48,27 @@ public class Build extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Build obj = CliRunner.initJc(new Build(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/CliSupport.java
+++ b/src/main/java/org/nanopub/op/CliSupport.java
@@ -1,0 +1,67 @@
+package org.nanopub.op;
+
+import com.beust.jcommander.ParameterException;
+
+/**
+ * Shared plumbing for the command-line tools in this package.
+ * <p>
+ * The tools keep their exit-code handling here rather than calling
+ * {@link System#exit} from their own {@code main}, so that the outcome of a run
+ * can be checked by a caller (including a test) without ending the JVM.
+ */
+final class CliSupport {
+
+    private CliSupport() {
+    }
+
+    /**
+     * The body of a command-line tool: everything between parsing the arguments
+     * and finishing.
+     */
+    @FunctionalInterface
+    interface CliBody {
+
+        /**
+         * Runs the tool.
+         *
+         * @throws Exception if the run fails for any reason
+         */
+        void run() throws Exception;
+    }
+
+    /**
+     * Runs the given body and maps its outcome to a process exit code.
+     * <p>
+     * A {@link ParameterException} means the arguments were wrong, and
+     * JCommander has already printed the usage, so nothing more is reported
+     * here. Any other failure gets its stack trace printed before the failing
+     * status is returned.
+     *
+     * @param body the body of the tool
+     * @return 0 if the body completed, 1 if it failed
+     */
+    static int execute(CliBody body) {
+        try {
+            body.run();
+            return 0;
+        } catch (ParameterException ex) {
+            return 1;
+        } catch (Exception ex) {
+            ex.printStackTrace();
+            return 1;
+        }
+    }
+
+    /**
+     * Ends the process with the given status, unless it is zero, in which case
+     * the caller simply returns and the JVM shuts down on its own.
+     *
+     * @param status the process exit code
+     */
+    static void exitWith(int status) {
+        if (status != 0) {
+            System.exit(status);
+        }
+    }
+
+}

--- a/src/main/java/org/nanopub/op/Count.java
+++ b/src/main/java/org/nanopub/op/Count.java
@@ -38,8 +38,7 @@ public class Count extends CliRunner {
      * @param args command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -50,16 +49,7 @@ public class Count extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Count obj = CliRunner.initJc(new Count(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Count(), args).run());
     }
 
     /**

--- a/src/main/java/org/nanopub/op/Count.java
+++ b/src/main/java/org/nanopub/op/Count.java
@@ -38,14 +38,27 @@ public class Count extends CliRunner {
      * @param args command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Count obj = CliRunner.initJc(new Count(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Create.java
+++ b/src/main/java/org/nanopub/op/Create.java
@@ -35,14 +35,27 @@ public class Create extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Create obj = CliRunner.initJc(new Create(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Create.java
+++ b/src/main/java/org/nanopub/op/Create.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -35,8 +34,7 @@ public class Create extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -47,16 +45,7 @@ public class Create extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Create obj = CliRunner.initJc(new Create(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Create(), args).run());
     }
 
     private RDFFormat rdfOutFormat;

--- a/src/main/java/org/nanopub/op/Decontextualize.java
+++ b/src/main/java/org/nanopub/op/Decontextualize.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
@@ -42,8 +41,7 @@ public class Decontextualize extends CliRunner {
      * @param args Command line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -54,16 +52,7 @@ public class Decontextualize extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Decontextualize obj = CliRunner.initJc(new Decontextualize(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Decontextualize(), args).run());
     }
 
     private RDFFormat rdfInFormat;

--- a/src/main/java/org/nanopub/op/Decontextualize.java
+++ b/src/main/java/org/nanopub/op/Decontextualize.java
@@ -42,14 +42,27 @@ public class Decontextualize extends CliRunner {
      * @param args Command line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Decontextualize obj = CliRunner.initJc(new Decontextualize(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/ExportJson.java
+++ b/src/main/java/org/nanopub/op/ExportJson.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -40,8 +39,7 @@ public class ExportJson extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -52,16 +50,7 @@ public class ExportJson extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            ExportJson obj = CliRunner.initJc(new ExportJson(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new ExportJson(), args).run());
     }
 
     private RDFFormat rdfInFormat;

--- a/src/main/java/org/nanopub/op/ExportJson.java
+++ b/src/main/java/org/nanopub/op/ExportJson.java
@@ -40,14 +40,27 @@ public class ExportJson extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             ExportJson obj = CliRunner.initJc(new ExportJson(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Extract.java
+++ b/src/main/java/org/nanopub/op/Extract.java
@@ -54,14 +54,27 @@ public class Extract extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Extract obj = CliRunner.initJc(new Extract(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Extract.java
+++ b/src/main/java/org/nanopub/op/Extract.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -54,8 +53,7 @@ public class Extract extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -66,16 +64,7 @@ public class Extract extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Extract obj = CliRunner.initJc(new Extract(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Extract(), args).run());
     }
 
     private RDFFormat rdfInFormat, rdfOutFormat;

--- a/src/main/java/org/nanopub/op/Filter.java
+++ b/src/main/java/org/nanopub/op/Filter.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
@@ -60,8 +59,7 @@ public class Filter extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -72,16 +70,7 @@ public class Filter extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Filter obj = CliRunner.initJc(new Filter(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Filter(), args).run());
     }
 
     private RDFFormat rdfInFormat, rdfOutFormat;

--- a/src/main/java/org/nanopub/op/Filter.java
+++ b/src/main/java/org/nanopub/op/Filter.java
@@ -60,14 +60,27 @@ public class Filter extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Filter obj = CliRunner.initJc(new Filter(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Fingerprint.java
+++ b/src/main/java/org/nanopub/op/Fingerprint.java
@@ -50,8 +50,7 @@ public class Fingerprint extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -62,17 +61,11 @@ public class Fingerprint extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
+        return CliSupport.execute(() -> {
             Fingerprint obj = CliRunner.initJc(new Fingerprint(), args);
             obj.init();
             obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        });
     }
 
     private Fingerprint() {

--- a/src/main/java/org/nanopub/op/Fingerprint.java
+++ b/src/main/java/org/nanopub/op/Fingerprint.java
@@ -50,15 +50,28 @@ public class Fingerprint extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Fingerprint obj = CliRunner.initJc(new Fingerprint(), args);
             obj.init();
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Gml.java
+++ b/src/main/java/org/nanopub/op/Gml.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
@@ -40,8 +39,7 @@ public class Gml extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -52,16 +50,7 @@ public class Gml extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Gml obj = CliRunner.initJc(new Gml(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Gml(), args).run());
     }
 
     private RDFFormat rdfInFormat;

--- a/src/main/java/org/nanopub/op/Gml.java
+++ b/src/main/java/org/nanopub/op/Gml.java
@@ -40,14 +40,27 @@ public class Gml extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Gml obj = CliRunner.initJc(new Gml(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Import.java
+++ b/src/main/java/org/nanopub/op/Import.java
@@ -49,8 +49,7 @@ public class Import extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -61,20 +60,14 @@ public class Import extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
+        return CliSupport.execute(() -> {
             Import obj = CliRunner.initJc(new Import(), args);
             if (obj.inputFiles.size() != 1) {
                 obj.getJc().usage();
-                return 1;
+                throw new ParameterException("Exactly one input file is expected");
             }
             obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        });
     }
 
     private RDFFormat rdfInFormat, rdfOutFormat;

--- a/src/main/java/org/nanopub/op/Import.java
+++ b/src/main/java/org/nanopub/op/Import.java
@@ -49,18 +49,31 @@ public class Import extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Import obj = CliRunner.initJc(new Import(), args);
             if (obj.inputFiles.size() != 1) {
                 obj.getJc().usage();
-                System.exit(1);
+                return 1;
             }
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/IndexReuse.java
+++ b/src/main/java/org/nanopub/op/IndexReuse.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -73,8 +72,7 @@ public class IndexReuse extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -85,16 +83,7 @@ public class IndexReuse extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            IndexReuse obj = CliRunner.initJc(new IndexReuse(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new IndexReuse(), args).run());
     }
 
     private IRI previousIndexUri = null;

--- a/src/main/java/org/nanopub/op/IndexReuse.java
+++ b/src/main/java/org/nanopub/op/IndexReuse.java
@@ -73,14 +73,27 @@ public class IndexReuse extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             IndexReuse obj = CliRunner.initJc(new IndexReuse(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Namespaces.java
+++ b/src/main/java/org/nanopub/op/Namespaces.java
@@ -58,15 +58,28 @@ public class Namespaces extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Namespaces obj = CliRunner.initJc(new Namespaces(), args);
             obj.init();
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Namespaces.java
+++ b/src/main/java/org/nanopub/op/Namespaces.java
@@ -58,8 +58,7 @@ public class Namespaces extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -70,17 +69,11 @@ public class Namespaces extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
+        return CliSupport.execute(() -> {
             Namespaces obj = CliRunner.initJc(new Namespaces(), args);
             obj.init();
             obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        });
     }
 
     /**

--- a/src/main/java/org/nanopub/op/Reuse.java
+++ b/src/main/java/org/nanopub/op/Reuse.java
@@ -72,8 +72,7 @@ public class Reuse extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -84,17 +83,11 @@ public class Reuse extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
+        return CliSupport.execute(() -> {
             Reuse obj = CliRunner.initJc(new Reuse(), args);
             obj.init();
             obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        });
     }
 
     private static final String multipleNanopubs = "MULTI";

--- a/src/main/java/org/nanopub/op/Reuse.java
+++ b/src/main/java/org/nanopub/op/Reuse.java
@@ -72,15 +72,28 @@ public class Reuse extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Reuse obj = CliRunner.initJc(new Reuse(), args);
             obj.init();
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Tar.java
+++ b/src/main/java/org/nanopub/op/Tar.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import net.trustyuri.TrustyUriUtils;
 import org.apache.commons.codec.Charsets;
@@ -39,8 +38,7 @@ public class Tar extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -51,16 +49,7 @@ public class Tar extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Tar obj = CliRunner.initJc(new Tar(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Tar(), args).run());
     }
 
     private RDFFormat rdfInFormat;

--- a/src/main/java/org/nanopub/op/Tar.java
+++ b/src/main/java/org/nanopub/op/Tar.java
@@ -39,14 +39,27 @@ public class Tar extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Tar obj = CliRunner.initJc(new Tar(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Topic.java
+++ b/src/main/java/org/nanopub/op/Topic.java
@@ -43,8 +43,7 @@ public class Topic extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -55,17 +54,11 @@ public class Topic extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
+        return CliSupport.execute(() -> {
             Topic obj = CliRunner.initJc(new Topic(), args);
             obj.init();
             obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        });
     }
 
     /**

--- a/src/main/java/org/nanopub/op/Topic.java
+++ b/src/main/java/org/nanopub/op/Topic.java
@@ -43,15 +43,28 @@ public class Topic extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Topic obj = CliRunner.initJc(new Topic(), args);
             obj.init();
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Union.java
+++ b/src/main/java/org/nanopub/op/Union.java
@@ -41,14 +41,27 @@ public class Union extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
+        int status = execute(args);
+        if (status != 0) System.exit(status);
+    }
+
+    /**
+     * Runs the tool and returns the process exit code, rather than ending the JVM itself,
+     * so that callers (including tests) can check the outcome.
+     *
+     * @param args command-line arguments
+     * @return 0 if the run completed, 1 if it failed
+     */
+    static int execute(String[] args) {
         try {
             Union obj = CliRunner.initJc(new Union(), args);
             obj.run();
+            return 0;
         } catch (ParameterException ex) {
-            System.exit(1);
+            return 1;
         } catch (Exception ex) {
             ex.printStackTrace();
-            System.exit(1);
+            return 1;
         }
     }
 

--- a/src/main/java/org/nanopub/op/Union.java
+++ b/src/main/java/org/nanopub/op/Union.java
@@ -1,6 +1,5 @@
 package org.nanopub.op;
 
-import com.beust.jcommander.ParameterException;
 import net.trustyuri.TrustyUriException;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
@@ -41,8 +40,7 @@ public class Union extends CliRunner {
      * @param args Command-line arguments
      */
     public static void main(String[] args) {
-        int status = execute(args);
-        if (status != 0) System.exit(status);
+        CliSupport.exitWith(execute(args));
     }
 
     /**
@@ -53,16 +51,7 @@ public class Union extends CliRunner {
      * @return 0 if the run completed, 1 if it failed
      */
     static int execute(String[] args) {
-        try {
-            Union obj = CliRunner.initJc(new Union(), args);
-            obj.run();
-            return 0;
-        } catch (ParameterException ex) {
-            return 1;
-        } catch (Exception ex) {
-            ex.printStackTrace();
-            return 1;
-        }
+        return CliSupport.execute(() -> CliRunner.initJc(new Union(), args).run());
     }
 
     private RDFFormat rdfInFormat, rdfOutFormat;

--- a/src/test/java/org/nanopub/op/CliSupportTest.java
+++ b/src/test/java/org/nanopub/op/CliSupportTest.java
@@ -1,0 +1,67 @@
+package org.nanopub.op;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import com.beust.jcommander.ParameterException;
+
+/**
+ * Tests the plumbing that every tool in this package shares. The tools
+ * themselves only need to check their own behaviour, since the mapping from an
+ * outcome to an exit code lives here.
+ */
+class CliSupportTest {
+
+    @Test
+    void aCompletedRunSucceeds() {
+        assertEquals(0, CliSupport.execute(() -> {
+        }));
+    }
+
+    @Test
+    void badArgumentsFailWithoutFurtherReporting() {
+        String printed = captureStandardError(()
+                -> assertEquals(1, CliSupport.execute(() -> {
+                    throw new ParameterException("missing argument");
+                })));
+
+        // JCommander has already printed the usage, so nothing is added here
+        assertTrue(printed.isBlank(), printed);
+    }
+
+    @Test
+    void anyOtherFailureIsReportedWithItsStackTrace() {
+        String printed = captureStandardError(()
+                -> assertEquals(1, CliSupport.execute(() -> {
+                    throw new IOException("no such file");
+                })));
+
+        assertTrue(printed.contains("java.io.IOException: no such file"), printed);
+    }
+
+    @Test
+    void exitWithDoesNothingForASuccessfulStatus() {
+        // if this called System.exit the test JVM would not survive to make the assertion
+        assertDoesNotThrow(() -> CliSupport.exitWith(0));
+    }
+
+    private static String captureStandardError(Runnable action) {
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        try {
+            System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+            action.run();
+        } finally {
+            System.setErr(originalErr);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+}

--- a/src/test/java/org/nanopub/op/OpToolsTest.java
+++ b/src/test/java/org/nanopub/op/OpToolsTest.java
@@ -1,0 +1,255 @@
+package org.nanopub.op;
+
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.utils.TestUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.nanopub.utils.TestUtils.anyIri;
+import static org.nanopub.utils.TestUtils.vf;
+
+/**
+ * Drives each command-line tool in this package through its {@code execute}
+ * method, which returns the exit code instead of ending the JVM.
+ * <p>
+ * The tools share a shape — read something, write something out — so they are
+ * covered here together rather than in seventeen near-identical test classes.
+ */
+class OpToolsTest {
+
+    /**
+     * What a tool expects to be pointed at.
+     */
+    private enum Input {
+        /**
+         * Plain nanopubs, which is what most of the tools read.
+         */
+        NANOPUBS,
+        /**
+         * Nanopubs with a trusty URI, which Tar needs to name its archive
+         * entries.
+         */
+        TRUSTY_NANOPUBS,
+        /**
+         * An ordinary RDF document, which Build turns into nanopubs.
+         */
+        PLAIN_RDF,
+        /**
+         * The line-based cache that Reuse writes with -c, and that IndexReuse
+         * reads.
+         */
+        NANOPUB_CACHE,
+        /**
+         * Nothing: the tool takes no input file.
+         */
+        NONE
+    }
+
+    /**
+     * One tool, with the input it expects and the arguments that make it do its
+     * job. The argument function is handed the input file and the directory to
+     * write into.
+     */
+    private record Tool(String name,
+            Input input,
+            BiFunction<File, File, String[]> arguments,
+            Function<String[], Integer> execute) {
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    private static File out(File dir, String name) {
+        return new File(dir, name);
+    }
+
+    static Stream<Tool> tools() {
+        return Stream.of(
+                new Tool("Aggregate", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-a", out(dir, "assertion.txt").getPath(), in.getPath()}, Aggregate::execute),
+                new Tool("Build", Input.PLAIN_RDF, (in, dir) -> new String[]{
+            "-o", out(dir, "built.trig").getPath(), in.getPath()}, Build::execute),
+                new Tool("Count", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-r", out(dir, "counts.txt").getPath(), in.getPath()}, Count::execute),
+                new Tool("Create", Input.NONE, (in, dir) -> new String[]{
+            "-o", out(dir, "created.trig").getPath()}, Create::execute),
+                new Tool("Decontextualize", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "plain.trig").getPath(), in.getPath()}, Decontextualize::execute),
+                new Tool("ExportJson", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "export.json").getPath(), in.getPath()}, ExportJson::execute),
+                new Tool("Extract", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-a", "-o", out(dir, "assertions.trig").getPath(), in.getPath()}, Extract::execute),
+                new Tool("Filter", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "filtered.trig").getPath(), in.getPath()}, Filter::execute),
+                new Tool("Fingerprint", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "fingerprints.txt").getPath(), in.getPath()}, Fingerprint::execute),
+                new Tool("Gml", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "graph.gml").getPath(), in.getPath()}, Gml::execute),
+                new Tool("Namespaces", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-a", out(dir, "namespaces.txt").getPath(), in.getPath()}, Namespaces::execute),
+                new Tool("Tar", Input.TRUSTY_NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "nanopubs.tar").getPath(), in.getPath()}, Tar::execute),
+                new Tool("Topic", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "topics.txt").getPath(), in.getPath()}, Topic::execute),
+                new Tool("Union", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "union.trig").getPath(), in.getPath()}, Union::execute),
+                // without -x, Reuse and IndexReuse create an initial dataset rather than reusing one
+                new Tool("Reuse", Input.NANOPUBS, (in, dir) -> new String[]{
+            "-o", out(dir, "reused.trig").getPath(),
+            "-c", out(dir, "cache.txt").getPath(), in.getPath()}, Reuse::execute),
+                new Tool("IndexReuse", Input.NANOPUB_CACHE, (in, dir) -> new String[]{
+            "-o", out(dir, "index.trig").getPath(), in.getPath()}, IndexReuse::execute)
+        );
+    }
+
+    private Map<Input, File> inputs;
+
+    @BeforeEach
+    void writeInputs(@TempDir File tempDir) throws Exception {
+        inputs = new EnumMap<>(Input.class);
+        inputs.put(Input.NANOPUBS, write(tempDir, "nanopubs.trig",
+                () -> nanopub("https://example.org/np1#", "first").writeToString(RDFFormat.TRIG)
+                + nanopub("https://example.org/np2#", "second").writeToString(RDFFormat.TRIG)));
+        inputs.put(Input.TRUSTY_NANOPUBS, write(tempDir, "trusty.trig",
+                () -> trustyNanopub("first").writeToString(RDFFormat.TRIG)
+                + trustyNanopub("second").writeToString(RDFFormat.TRIG)));
+        inputs.put(Input.PLAIN_RDF, write(tempDir, "plain.ttl", () -> """
+                @prefix ex: <https://example.org/> .
+                ex:s1 ex:p "one" .
+                ex:s1 ex:q "two" .
+                ex:s2 ex:p "three" .
+                """));
+        // IndexReuse consumes the cache that Reuse produces, so the tools are chained here
+        // the same way they are on the command line
+        File cache = new File(tempDir, "cache.txt");
+        assertEquals(0, quietly(() -> Reuse.execute(new String[]{
+            "-c", cache.getPath(),
+            "-o", new File(tempDir, "reused.trig").getPath(),
+            inputs.get(Input.NANOPUBS).getPath()})),
+                "the cache fixture could not be built");
+        inputs.put(Input.NANOPUB_CACHE, cache);
+
+        // the tools that take no input are still handed a file, which they ignore
+        inputs.put(Input.NONE, inputs.get(Input.NANOPUBS));
+    }
+
+    private interface ContentSupplier {
+
+        String get() throws Exception;
+    }
+
+    private static File write(File dir, String name, ContentSupplier content) throws Exception {
+        File file = new File(dir, name);
+        Files.writeString(file.toPath(), content.get(), StandardCharsets.UTF_8);
+        return file;
+    }
+
+    private static Nanopub nanopub(String uri, String label) throws Exception {
+        return creatorFor(uri, label).finalizeNanopub();
+    }
+
+    private static Nanopub trustyNanopub(String label) throws Exception {
+        return creatorFor("http://purl.org/nanopub/temp/" + label + "/", label).finalizeTrustyNanopub();
+    }
+
+    private static NanopubCreator creatorFor(String uri, String label) throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator(uri);
+        creator.addAssertionStatement(anyIri, RDFS.LABEL, vf.createLiteral(label));
+        creator.addProvenanceStatement(anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        return creator;
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("tools")
+    void succeedsOnAWellFormedInput(Tool tool, @TempDir File outputDir) {
+        String[] args = tool.arguments().apply(inputs.get(tool.input()), outputDir);
+
+        assertEquals(0, quietly(() -> tool.execute().apply(args)),
+                tool + " should have completed successfully");
+        assertTrue(outputDir.listFiles() != null && outputDir.listFiles().length > 0,
+                tool + " should have written something");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("tools")
+    void failsOnAnUnknownOption(Tool tool, @TempDir File outputDir) {
+        String[] args = tool.arguments().apply(inputs.get(tool.input()), outputDir);
+        String[] withBadOption = new String[args.length + 1];
+        withBadOption[0] = "--no-such-option";
+        System.arraycopy(args, 0, withBadOption, 1, args.length);
+
+        assertEquals(1, quietly(() -> tool.execute().apply(withBadOption)),
+                tool + " should have rejected the unknown option");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("tools")
+    void failsOnAnUnreadableInput(Tool tool, @TempDir File outputDir) {
+        assumeTakesAnInput(tool);
+        File missing = new File(outputDir, "does-not-exist.trig");
+
+        assertEquals(1, quietly(() -> tool.execute().apply(tool.arguments().apply(missing, outputDir))),
+                tool + " should have reported the missing input");
+    }
+
+    private static void assumeTakesAnInput(Tool tool) {
+        org.junit.jupiter.api.Assumptions.assumeTrue(tool.input() != Input.NONE,
+                tool + " takes no input file");
+    }
+
+    @org.junit.jupiter.api.Test
+    void importRejectsAnUnknownType(@TempDir File outputDir) {
+        // only "cedar" is supported, and the type is required
+        String[] args = {"-t", "no-such-type", "-o", out(outputDir, "imported.trig").getPath(),
+            inputs.get(Input.NANOPUBS).getPath()};
+
+        assertEquals(1, quietly(() -> Import.execute(args)));
+    }
+
+    @org.junit.jupiter.api.Test
+    void importNeedsExactlyOneInputFile(@TempDir File outputDir) {
+        File input = inputs.get(Input.NANOPUBS);
+        String[] args = {"-t", "cedar", input.getPath(), input.getPath()};
+
+        assertEquals(1, quietly(() -> Import.execute(args)));
+    }
+
+    /**
+     * Runs the tool with its output swallowed, so that a passing test run stays
+     * readable.
+     */
+    private static int quietly(Supplier<Integer> action) {
+        PrintStream originalOut = System.out;
+        PrintStream originalErr = System.err;
+        try {
+            System.setOut(new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+            System.setErr(new PrintStream(new ByteArrayOutputStream(), true, StandardCharsets.UTF_8));
+            return action.get();
+        } finally {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

The command-line tools in `org.nanopub.op` ended their `main` with `System.exit(1)` inside a try/catch. That made them impossible to drive from a test — any failure path took the test JVM down with it — so the package sat at **2.9% coverage**.

This makes them testable and then tests them:

- **`refactor(op)`** — `main` delegates to a package-private `execute(String[])` that returns the exit code, with the shared plumbing in one place.
- **`test(op)`, `test(cli-support)`** — 54 tests driving every tool through `execute`.

**`org.nanopub.op*`: 2.9% → 51.5%. Project: 73.9% → 81.1%** (11,883 → 8,608 missed instructions).

## The refactor

Each tool now reads:

```java
public static void main(String[] args) {
    CliSupport.exitWith(execute(args));
}

static int execute(String[] args) {
    return CliSupport.execute(() -> CliRunner.initJc(new Build(), args).run());
}
```

with all the exception handling in a new package-private `org.nanopub.op.CliSupport`. That removed a lot of duplication:

| | before | after |
|---|---|---|
| wrapper instructions | 493 | 169 |
| wrapper branches | 36, spread over 17 classes | 2, in one place |
| tests needed to cover the plumbing | ~3 per class (~51) | 3 in total |

`run()` stays private in every tool — a static method can reach its own class's private members, so no visibility had to change.

## No breaking changes

- `main(String[])` keeps its signature, so the reflective dispatchers in `org.nanopub.Run` and `org.nanopub.op.Run` (`getMethod("main", String[].class)`) are unaffected.
- Exit codes and output are identical: success returns normally, failures exit 1, stack traces are still printed for anything other than a `ParameterException`.
- `CliSupport` is package-private, so **no new published API** and nothing release-triggering.
- `Import`'s argument guard now signals through `ParameterException` instead of exiting inline; same usage output, same status.
- `op/Run.java` is untouched — its `main` has a different shape.

## Tests

- `CliSupportTest` — the shared plumbing: success, `ParameterException` (silent, since JCommander has already printed the usage), any other failure (stack trace printed), and `exitWith(0)` not exiting.
- `OpToolsTest` — parameterized over all 16 tools, three cases each: succeeds on a well-formed input, fails on an unknown option, fails on an unreadable input. Plus two `Import`-specific cases.

Three tools needed their own fixture, which the tests surfaced:

- **`Build`** takes plain RDF *documents*, not nanopubs — feeding it nanopubs fails with "Two nanopub URIs found".
- **`Tar`** names its archive entries from the artifact code, so it only accepts **trusty** nanopubs.
- **`IndexReuse`** reads the line-based cache that `Reuse -c` writes, not nanopubs. The fixture chains the two, the way they are chained on the command line.

## Worth knowing

`Tar` throws a bare `NullPointerException` on non-trusty input (`filename` is null at `Tar.java:90`, because `TrustyUriUtils.getArtifactCode` returned null) rather than reporting the problem. Not addressed here — it is a behaviour change rather than a testability one.

## Still uncovered in `op`

`Reuse` (555) and `IndexReuse` (302) have reuse paths that only run with `-x`, so covering them means building a prior dataset. `Import$CedarNanopubImporter` (364) needs a CEDAR JSON fixture. `op/Run` (237) is the dispatcher, still `System.exit`-shaped. The Disgenet/Wikipathways/MetaboliteSpecies fingerprint and topic handlers (~510) are selected with `-h` and need domain-specific inputs.

## Follow-up

#123 records promoting `CliSupport` to a public `CliRunner.execute`, so the ~24 CLI classes outside `op` can use it. That one is new public API, so it is a `feat` rather than a `refactor` — deliberately kept out of this PR.

## Test plan

- `./mvnw test` — 941 tests, 0 failures, 1 skipped (`Create` takes no input file, so the missing-input case does not apply to it).
- `./mvnw test jacoco:report` for the coverage figures above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
