### PR TITLE
fix: allow a temp URI as signer, so an agent can self-sign its own introduction

### DIFF
--- a/src/main/java/org/nanopub/extra/security/SignNanopub.java
+++ b/src/main/java/org/nanopub/extra/security/SignNanopub.java
@@ -52,7 +52,7 @@ public class SignNanopub extends CliRunner {
     @com.beust.jcommander.Parameter(names = "-R", description = "Resolve cross-nanopub references based on prefixes")
     private boolean resolveCrossRefsPrefixBased = false;
 
-    @com.beust.jcommander.Parameter(names = "-s", description = "The orcid IRI of the signer")
+    @com.beust.jcommander.Parameter(names = "-s", description = "The IRI of the signer, typically an ORCID IRI. It can also be a sub-IRI of the nanopub being signed, given under its temporary URI (e.g. http://purl.org/nanopub/temp/np001/my-bot), which lets an agent self-sign its own introduction")
     private String signer;
 
     @com.beust.jcommander.Parameter(names = "--profile", description = "Profile file for signer iri and key files, " + "defaults to ~/.nanopub/profile.yaml")

--- a/src/main/java/org/nanopub/extra/security/SignatureUtils.java
+++ b/src/main/java/org/nanopub/extra/security/SignatureUtils.java
@@ -144,12 +144,12 @@ public class SignatureUtils {
     public static Nanopub createSignedNanopub(Nanopub preNanopub, TransformContext c)
             throws GeneralSecurityException, RDFHandlerException, TrustyUriException, MalformedNanopubException {
 
-        String u = preNanopub.getUri().stringValue();
-        if (!preNanopub.getHeadUri().stringValue().startsWith(u) ||
-            !preNanopub.getAssertionUri().stringValue().startsWith(u) ||
-            !preNanopub.getProvenanceUri().stringValue().startsWith(u) ||
-            !preNanopub.getPubinfoUri().stringValue().startsWith(u)) {
-            throw new TrustyUriException("Graph URIs need have the nanopub URI as prefix: " + u + "...");
+        String preNanopubUri = preNanopub.getUri().stringValue();
+        if (!preNanopub.getHeadUri().stringValue().startsWith(preNanopubUri) ||
+            !preNanopub.getAssertionUri().stringValue().startsWith(preNanopubUri) ||
+            !preNanopub.getProvenanceUri().stringValue().startsWith(preNanopubUri) ||
+            !preNanopub.getPubinfoUri().stringValue().startsWith(preNanopubUri)) {
+            throw new TrustyUriException("Graph URIs need have the nanopub URI as prefix: " + preNanopubUri + "...");
         }
         List<Statement> illTyped = NanopubUtils.getIllTypedLiteralStatements(preNanopub);
         if (!illTyped.isEmpty()) {
@@ -159,11 +159,20 @@ public class SignatureUtils {
 
         RdfFileContent r = new RdfFileContent(RDFFormat.TRIG);
         IRI npUri;
+        IRI signer = c.getSigner();
         Map<Resource, IRI> tempUriReplacerMap = null;
         if (TempUriReplacer.hasTempUri(preNanopub)) {
             npUri = vf.createIRI(TempUriReplacer.normUri);
             tempUriReplacerMap = new HashMap<>();
             NanopubUtils.propagateToHandler(preNanopub, new TempUriReplacer(preNanopub, r, tempUriReplacerMap));
+            // The signer statement is added further below and therefore bypasses the replacement above.
+            // If the signer is introduced by this very nanopub (self-signed introduction of an agent),
+            // its temporary URI has to be replaced here too:
+            if (signer != null && signer.stringValue().startsWith(preNanopubUri)) {
+                IRI replacedSigner = vf.createIRI(signer.stringValue().replace(preNanopubUri, TempUriReplacer.normUri));
+                tempUriReplacerMap.put(signer, replacedSigner);
+                signer = replacedSigner;
+            }
         } else {
             npUri = preNanopub.getUri();
             NanopubUtils.propagateToHandler(preNanopub, r);
@@ -203,8 +212,8 @@ public class SignatureUtils {
         preStatements.add(vf.createStatement(signatureElUri, NPX.HAS_PUBLIC_KEY, publicKeyLiteral, piUri));
         Literal algorithmLiteral = vf.createLiteral(c.getSignatureAlgorithm().name());
         preStatements.add(vf.createStatement(signatureElUri, NPX.HAS_ALGORITHM, algorithmLiteral, piUri));
-        if (c.getSigner() != null) {
-            preStatements.add(vf.createStatement(signatureElUri, NPX.SIGNED_BY, c.getSigner(), piUri));
+        if (signer != null) {
+            preStatements.add(vf.createStatement(signatureElUri, NPX.SIGNED_BY, signer, piUri));
         }
 
         // Preprocess statements that are covered by signature:

--- a/src/test/java/org/nanopub/extra/security/SignatureUtilsTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignatureUtilsTest.java
@@ -2,12 +2,15 @@ package org.nanopub.extra.security;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.junit.jupiter.api.Test;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubCreator;
 import org.nanopub.testsuite.NanopubTestSuite;
 import org.nanopub.testsuite.SigningKeyPair;
+import org.nanopub.trusty.TempUriReplacer;
+import org.nanopub.trusty.TrustyNanopubUtils;
 import org.nanopub.vocabulary.NPX;
 
 import java.security.KeyPair;
@@ -288,6 +291,45 @@ class SignatureUtilsTest {
         NanopubSignatureElement element = SignatureUtils.getSignatureElement(signedNanopub());
 
         assertTrue(SignatureUtils.hasValidSignature(element));
+    }
+
+    // ------------------------------------------------- self-signed introduction
+
+    /**
+     * An agent introducing itself signs with a signer IRI that is a sub-IRI of the very nanopub being
+     * signed, so the signer only becomes known once the artifact code is computed. The temporary URI
+     * therefore has to be replaced in the signer just like everywhere else.
+     */
+    @Test
+    void createSignedNanopubResolvesASignerUnderTheTempUri() throws Exception {
+        IRI npUri = vf.createIRI(TempUriReplacer.tempUri + "np001/");
+        IRI tempSigner = vf.createIRI(npUri + "my-bot");
+        NanopubCreator creator = new NanopubCreator(npUri);
+        creator.addAssertionStatement(tempSigner, RDFS.LABEL, vf.createLiteral("my bot"));
+        creator.addProvenanceStatement(anyIri, anyIri);
+        creator.addPubinfoStatement(DCTERMS.CREATOR, tempSigner);
+        TransformContext c = new TransformContext(SignatureAlgorithm.RSA, transformContext().getKey(),
+                tempSigner, false, false, false);
+
+        Nanopub signed = SignNanopub.signAndTransform(creator.finalizeNanopub(), c);
+
+        IRI resolvedSigner = vf.createIRI(signed.getUri() + "/my-bot");
+        assertEquals(Set.of(resolvedSigner), SignatureUtils.getSignatureElement(signed).getSigners());
+        // the signer is now the same IRI as the creator, and the signature covers it
+        assertTrue(signed.getPubinfo().contains(
+                vf.createStatement(signed.getUri(), DCTERMS.CREATOR, resolvedSigner, signed.getPubinfoUri())));
+        assertTrue(SignatureUtils.hasValidSignature(SignatureUtils.getSignatureElement(signed)));
+        assertTrue(TrustyNanopubUtils.isValidTrustyNanopub(signed));
+    }
+
+    /**
+     * A signer that is not a sub-IRI of the nanopub being signed stays untouched.
+     */
+    @Test
+    void createSignedNanopubLeavesAnExternalSignerAlone() throws Exception {
+        IRI signer = vf.createIRI("https://orcid.org/0000-0000-0000-0000");
+
+        assertEquals(Set.of(signer), SignatureUtils.getSignatureElement(signedNanopub()).getSigners());
     }
 
 }


### PR DESCRIPTION
Fixes #127

## Problem

The signer statement was added to the pre-nanopub *after* the temp-URI replacement pass in `SignatureUtils.createSignedNanopub`, so a signer IRI under `http://purl.org/nanopub/temp/…` was hashed and emitted as an ordinary external IRI instead of a self-reference.

That made it impossible to self-sign an agent's own introduction, where the agent IRI is a sub-IRI of the very nanopub being signed. Every other reference (e.g. `dct:creator sub:my-bot`) was rewritten, but `npx:signedBy` kept the raw temp URI, and `check -v` reported `The signer is not a creator.` Feeding the resolved IRI back in is circular, since `npx:signedBy` is inside the hash.

## Fix

Resolve the signer through the same replacement, inside the `hasTempUri` branch, and record the mapping in the transform map so it is merged into the transform context like every other temp→final mapping. From there the existing machinery does the right thing: `RdfPreprocessor` normalises it as a self-reference for hashing, and the final rewrite emits the trusty sub-IRI.

The CLI help for `sign -s` now mentions this.

## Verification

CLI repro from the issue, same input and key, before vs. after:

```
sign -k mybot_id_rsa -s http://purl.org/nanopub/temp/np001/my-bot -o intro-signed.trig intro.trig
```

Before:
```turtle
sub:sig npx:signedBy <http://purl.org/nanopub/temp/np001/my-bot> .
```
`check -v` → `- The signer is not a creator.`

After:
```turtle
sub:sig npx:signedBy sub:my-bot .   # https://w3id.org/np/RAbKWRx…/my-bot
```
`check -v` → `Signed and trusty: …`, `CREATORS:` lists the same IRI, and the issue is gone.

An external ORCID signer is emitted untouched, as before.

## Tests

- `createSignedNanopubResolvesASignerUnderTheTempUri` — signs an introduction whose signer is a temp sub-IRI, asserts `npx:signedBy` resolves to the trusty sub-IRI, that it equals the rewritten `dct:creator` (the exact condition `NanopubVerifier` checks), that the signature verifies, and that the result is a valid trusty nanopub. Fails on the pre-fix code.
- `createSignedNanopubLeavesAnExternalSignerAlone` — an ORCID signer passes through unchanged.

Full suite: 1183 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
