### PR TITLE
fix: do not create or truncate the sign output file before signing

### DIFF
--- a/src/main/java/org/nanopub/extra/security/SignNanopub.java
+++ b/src/main/java/org/nanopub/extra/security/SignNanopub.java
@@ -3,7 +3,7 @@ package org.nanopub.extra.security;
 import com.beust.jcommander.ParameterException;
 import jakarta.xml.bind.DatatypeConverter;
 import net.trustyuri.TrustyUriException;
-import net.trustyuri.TrustyUriResource;
+import net.trustyuri.TrustyUriUtils;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -22,6 +22,7 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
 
@@ -126,48 +127,136 @@ public class SignNanopub extends CliRunner {
         }
         final TransformContext c = new TransformContext(algorithm, key, signerIri, resolveCrossRefs, resolveCrossRefsPrefixBased, ignoreSigned);
 
-        final OutputStream singleOut;
-        if (singleOutputFile != null) {
-            if (singleOutputFile.getName().matches(".*\\.(gz|gzip)")) {
-                singleOut = new GZIPOutputStream(new FileOutputStream(singleOutputFile));
-            } else {
-                singleOut = new FileOutputStream(singleOutputFile);
+        // The output files are opened lazily, so that a run that fails before anything is signed does
+        // not truncate an existing file or leave an empty one behind (see issue #129).
+        final LazyFileOutputStream singleOut = singleOutputFile == null ? null : new LazyFileOutputStream(singleOutputFile);
+        try {
+            for (File inputFile : inputNanopubFiles) {
+                final File outputFile;
+                final LazyFileOutputStream out;
+                if (singleOut == null) {
+                    outputFile = new File(inputFile.getParent(), "signed." + inputFile.getName());
+                    out = new LazyFileOutputStream(outputFile);
+                } else {
+                    outputFile = singleOutputFile;
+                    out = singleOut;
+                }
+                final RDFFormat inFormat = getFormat(inputFile, RDFFormat.TRIG);
+                final RDFFormat outFormat = getFormat(outputFile, RDFFormat.TRIG);
+                try {
+                    MultiNanopubRdfHandler.process(inFormat, inputFile, np -> {
+                        try {
+                            np = writeAsSignedTrustyNanopub(np, outFormat, c, out);
+                            if (verbose) {
+                                System.out.println("Nanopub URI: " + np.getUri());
+                            }
+                        } catch (RDFHandlerException | SignatureException | InvalidKeyException |
+                                 TrustyUriException ex) {
+                            ex.printStackTrace();
+                            throw new RuntimeException(ex);
+                        }
+                    });
+                    if (out != singleOut) {
+                        // this input was processed without error, so an input without nanopubs still
+                        // gets its (empty) output file, as it did before
+                        out.createIfNotWrittenTo();
+                    }
+                } finally {
+                    if (out != singleOut) {
+                        out.close();
+                    }
+                }
             }
-        } else {
-            singleOut = null;
+            if (singleOut != null) {
+                singleOut.createIfNotWrittenTo();
+            }
+        } finally {
+            if (singleOut != null) {
+                singleOut.close();
+            }
+        }
+    }
+
+    /**
+     * Determines the RDF format of a file from its name alone.
+     * <p>
+     * This derives the format the same way {@code TrustyUriResource.getFormat(RDFFormat)} does, but
+     * without opening the file: the output file does not exist yet at this point, as it is only created
+     * once there is something to write to it.
+     *
+     * @param file          the file whose format to determine
+     * @param defaultFormat the format to fall back to if the name does not identify one
+     * @return the RDF format of the file
+     */
+    private static RDFFormat getFormat(File file, RDFFormat defaultFormat) {
+        String mimetype = TrustyUriUtils.getMimetype(file.toString());
+        Optional<RDFFormat> format = mimetype == null ? Optional.empty() : Rio.getParserFormatForMIMEType(mimetype);
+        if (format.isEmpty()) {
+            format = Rio.getParserFormatForFileName(file.toString());
+        }
+        return format.orElse(defaultFormat);
+    }
+
+    /**
+     * An output stream to a file that is only created once something is actually written to it.
+     * <p>
+     * Opening a {@link java.io.FileOutputStream} truncates its target, and signing can fail before the
+     * first nanopub is written. Delaying the open until the first write keeps a failed run from
+     * destroying an existing file or leaving an empty one behind, while preserving the streaming
+     * behaviour for files with several nanopubs.
+     */
+    private static class LazyFileOutputStream extends OutputStream {
+
+        private final File file;
+        private OutputStream out;
+
+        LazyFileOutputStream(File file) {
+            this.file = file;
         }
 
-        for (File inputFile : inputNanopubFiles) {
-            File outputFile;
-            final OutputStream out;
-            if (singleOutputFile == null) {
-                outputFile = new File(inputFile.getParent(), "signed." + inputFile.getName());
-                if (inputFile.getName().matches(".*\\.(gz|gzip)")) {
-                    out = new GZIPOutputStream(new FileOutputStream(outputFile));
+        private OutputStream open() throws IOException {
+            if (out == null) {
+                if (file.getName().matches(".*\\.(gz|gzip)")) {
+                    out = new GZIPOutputStream(new FileOutputStream(file));
                 } else {
-                    out = new FileOutputStream(outputFile);
+                    out = new FileOutputStream(file);
                 }
-            } else {
-                outputFile = singleOutputFile;
-                out = singleOut;
             }
-            final RDFFormat inFormat = new TrustyUriResource(inputFile).getFormat(RDFFormat.TRIG);
-            final RDFFormat outFormat = new TrustyUriResource(outputFile).getFormat(RDFFormat.TRIG);
-            try (out) {
-                MultiNanopubRdfHandler.process(inFormat, inputFile, np -> {
-                    try {
-                        np = writeAsSignedTrustyNanopub(np, outFormat, c, out);
-                        if (verbose) {
-                            System.out.println("Nanopub URI: " + np.getUri());
-                        }
-                    } catch (RDFHandlerException | SignatureException | InvalidKeyException |
-                             TrustyUriException ex) {
-                        ex.printStackTrace();
-                        throw new RuntimeException(ex);
-                    }
-                });
+            return out;
+        }
+
+        /**
+         * Creates the file even though nothing was written to it. To be called only once the run has
+         * succeeded, never on the failure path.
+         */
+        void createIfNotWrittenTo() throws IOException {
+            open();
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            open().write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            open().write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            if (out != null) {
+                out.flush();
             }
         }
+
+        @Override
+        public void close() throws IOException {
+            if (out != null) {
+                out.close();
+            }
+        }
+
     }
 
     /**

--- a/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.nanopub.CliRunner;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubCreator;
+import org.nanopub.MultiNanopubRdfHandler;
 import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubProfile;
 import org.nanopub.testsuite.NanopubTestSuite;
@@ -212,9 +213,13 @@ class SignNanopubTest {
     }
 
     private static Nanopub preNanopub() throws Exception {
+        return preNanopub("an assertion");
+    }
+
+    private static Nanopub preNanopub(String label) throws Exception {
         NanopubCreator creator = new NanopubCreator(true);
         creator.addAssertionStatement(anyIri, org.eclipse.rdf4j.model.vocabulary.RDFS.LABEL,
-                TestUtils.vf.createLiteral("an assertion"));
+                TestUtils.vf.createLiteral(label));
         creator.addProvenanceStatement(anyIri, anyIri);
         creator.addPubinfoStatement(anyIri, anyIri);
         return creator.finalizeNanopub();
@@ -355,6 +360,100 @@ class SignNanopubTest {
 
         // the key cannot be read, but the file name has already selected the DSA algorithm
         assertThrows(Exception.class, signer::run);
+    }
+
+    // --------------------------------------------- output file integrity (#129)
+    @Test
+    void aFailedRunLeavesAnExistingOutputFileUntouched() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-sign-failed-single-output");
+        // an already signed nanopub is refused, so the run fails before anything is written
+        File input = writeToFile(tempDir.toFile(), "input.trig",
+                SignNanopub.signAndTransform(preNanopub(), transformContext(false)));
+        File output = new File(tempDir.toFile(), "out.trig");
+        Files.writeString(output.toPath(), "IMPORTANT EXISTING CONTENT\n");
+
+        SignNanopub signer = CliRunner.initJc(new SignNanopub(), new String[]{
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000",
+            "-o", output.getPath(), input.getPath()});
+
+        assertThrows(Exception.class, signer::run);
+        assertEquals("IMPORTANT EXISTING CONTENT\n", Files.readString(output.toPath()));
+    }
+
+    @Test
+    void aRunRefusingAnIllTypedLiteralLeavesTheOutputFileUntouched() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-sign-ill-typed-output");
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, anyIri, TestUtils.vf.createLiteral("two", XSD.INTEGER));
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        File input = writeToFile(tempDir.toFile(), "input.trig", creator.finalizeNanopub());
+        File output = new File(tempDir.toFile(), "out.trig");
+        Files.writeString(output.toPath(), "IMPORTANT EXISTING CONTENT\n");
+
+        SignNanopub signer = CliRunner.initJc(new SignNanopub(), new String[]{
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000",
+            "-o", output.getPath(), input.getPath()});
+
+        assertThrows(Exception.class, signer::run);
+        assertEquals("IMPORTANT EXISTING CONTENT\n", Files.readString(output.toPath()));
+    }
+
+    @Test
+    void aFailedRunDoesNotCreateTheDefaultOutputFile() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-sign-failed-default-output");
+        File input = writeToFile(tempDir.toFile(), "input.trig",
+                SignNanopub.signAndTransform(preNanopub(), transformContext(false)));
+
+        SignNanopub signer = CliRunner.initJc(new SignNanopub(), new String[]{
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()});
+
+        assertThrows(Exception.class, signer::run);
+        assertFalse(new File(tempDir.toFile(), "signed.input.trig").exists());
+    }
+
+    @Test
+    void aFailedRunDoesNotCreateAGzippedOutputFile() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-sign-failed-gz-output");
+        File input = writeToFile(tempDir.toFile(), "input.trig",
+                SignNanopub.signAndTransform(preNanopub(), transformContext(false)));
+        File output = new File(tempDir.toFile(), "out.trig.gz");
+
+        SignNanopub signer = CliRunner.initJc(new SignNanopub(), new String[]{
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000",
+            "-o", output.getPath(), input.getPath()});
+
+        assertThrows(Exception.class, signer::run);
+        assertFalse(output.exists());
+    }
+
+    @Test
+    void writesAnEmptyOutputFileForAnInputWithoutNanopubs() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-sign-empty-input");
+        File input = writeToFile(tempDir.toFile(), "input.trig");
+
+        CliRunner.initJc(new SignNanopub(), new String[]{
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000", input.getPath()}).run();
+
+        File output = new File(tempDir.toFile(), "signed.input.trig");
+        assertTrue(output.exists());
+        assertEquals(0, Files.size(output.toPath()));
+    }
+
+    @Test
+    void writesAllInputFilesToTheSingleOutputFile() throws Exception {
+        Path tempDir = Files.createTempDirectory("test-sign-several-inputs");
+        File first = writeToFile(tempDir.toFile(), "first.trig", preNanopub("the first assertion"));
+        File second = writeToFile(tempDir.toFile(), "second.trig", preNanopub("the second assertion"));
+        File output = new File(tempDir.toFile(), "out.trig");
+
+        CliRunner.initJc(new SignNanopub(), new String[]{
+            "-k", privateKeyPath(), "-s", "https://orcid.org/0000-0000-0000-0000",
+            "-o", output.getPath(), first.getPath(), second.getPath()}).run();
+
+        int[] count = new int[1];
+        MultiNanopubRdfHandler.process(RDFFormat.TRIG, output, np -> count[0]++);
+        assertEquals(2, count[0]);
     }
 
     @Test


### PR DESCRIPTION
Closes #129

## What happens

`sign` opened (and therefore truncated) its output file before it had parsed or signed anything. If signing then failed, an empty file was left behind — and if the output file already existed, its previous contents were destroyed. The same applied without `-o`: the per-input default `signed.<name>` was created empty next to the input, leaving a plausible-looking but empty artifact a later step could pick up.

## The fix

Lazy output streams (the first option suggested in the issue):

- New private `LazyFileOutputStream` wraps the destination and opens the `FileOutputStream`/`GZIPOutputStream` only on the **first actual write**. Since `signAndTransform` runs before anything is written, a run that fails to sign never touches the destination. Streaming for multi-nanopub files is unchanged.
- `createIfNotWrittenTo()` is called only on the success path, so an input that legitimately contains no nanopubs still produces its empty output file, as before.
- Format detection had to move off the file: `new TrustyUriResource(outputFile).getFormat(...)` opens the file to build the resource, which only worked because the old code had already created it. A small `getFormat(File, RDFFormat)` helper derives the format from the file name the same way `TrustyUriResource.getFormat` does. It is used for the input file too, which also drops a leaked `FileInputStream`/`GZIPInputStream` per input.

Partial output on a mid-file failure is left as it was — the issue calls that acceptable, and the exit code plus stderr still report the failure.

### One adjacent bug fixed along the way

The old `try (out)` inside the loop closed the shared `-o` stream after the **first** input file, so `np sign -o out.trig a.trig b.trig` failed with `Stream Closed`. `singleOut` is now closed once, after the loop.

## Tests

Six new tests in `SignNanopubTest` (24 in the class, 1191 in the full suite, all passing):

- `aRunRefusingAnIllTypedLiteralLeavesTheOutputFileUntouched` — the issue's exact repro
- `aFailedRunLeavesAnExistingOutputFileUntouched`
- `aFailedRunDoesNotCreateTheDefaultOutputFile`
- `aFailedRunDoesNotCreateAGzippedOutputFile`
- `writesAnEmptyOutputFileForAnInputWithoutNanopubs`
- `writesAllInputFilesToTheSingleOutputFile`

Confirmed these fail on `master` without the fix (3 failures + 1 error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)