### PR TITLE
feat: reject grlc query nanopublications whose SPARQL doesn't parse

### DIFF
--- a/src/main/java/org/nanopub/CheckNanopub.java
+++ b/src/main/java/org/nanopub/CheckNanopub.java
@@ -153,11 +153,18 @@ public class CheckNanopub extends CliRunner {
 
     private void check(Nanopub np) {
         List<Statement> illTyped = NanopubUtils.getIllTypedLiteralStatements(np);
+        List<Statement> invalidSparql = NanopubUtils.getInvalidSparqlStatements(np);
         if (TrustyNanopubUtils.isValidTrustyNanopub(np)) {
             if (!illTyped.isEmpty()) {
                 log("WARNING: TRUSTY NANOPUB WITH ILL-TYPED LITERAL(S): " + np.getUri() + "\n");
                 for (Statement st : illTyped) {
                     log("- " + NanopubUtils.describeIllTypedLiteral(st) + "\n");
+                }
+            }
+            if (!invalidSparql.isEmpty()) {
+                log("WARNING: TRUSTY NANOPUB WITH INVALID SPARQL: " + np.getUri() + "\n");
+                for (Statement st : invalidSparql) {
+                    log("- " + NanopubUtils.describeInvalidSparql(st) + "\n");
                 }
             }
             NanopubSignatureElement se = null;
@@ -220,12 +227,15 @@ public class CheckNanopub extends CliRunner {
         } else if (TrustyUriUtils.isPotentialTrustyUri(np.getUri())) {
             System.out.println("Looks like a trusty nanopub BUT VERIFICATION FAILED: " + np.getUri());
             report.countNotTrusty();
-        } else if (!illTyped.isEmpty()) {
-            // Trusty nanopubs with ill-typed literals are only warned about above, but a plain one is not
+        } else if (!illTyped.isEmpty() || !invalidSparql.isEmpty()) {
+            // Trusty nanopubs with these problems are only warned about above, but a plain one is not
             // fit to be signed and published, and is therefore reported as invalid.
             System.out.println("INVALID NANOPUB: " + np.getUri());
             for (Statement st : illTyped) {
                 System.out.println("- " + NanopubUtils.describeIllTypedLiteral(st));
+            }
+            for (Statement st : invalidSparql) {
+                System.out.println("- " + NanopubUtils.describeInvalidSparql(st));
             }
             report.countInvalid();
         } else {

--- a/src/main/java/org/nanopub/NanopubPatterns.java
+++ b/src/main/java/org/nanopub/NanopubPatterns.java
@@ -3,6 +3,7 @@ package org.nanopub;
 import org.nanopub.extra.aida.AidaPattern;
 import org.nanopub.extra.index.NanopubIndexPattern;
 import org.nanopub.extra.security.DigitalSignaturePattern;
+import org.nanopub.extra.services.GrlcQueryPattern;
 import org.nanopub.trusty.TrustyNanopubPattern;
 
 import java.util.ArrayList;
@@ -22,6 +23,7 @@ public class NanopubPatterns {
         addPattern(new NanopubIndexPattern());
         addPattern(new AidaPattern());
         addPattern(new DigitalSignaturePattern());
+        addPattern(new GrlcQueryPattern());
     }
 
     private NanopubPatterns() {}  // no instances allowed

--- a/src/main/java/org/nanopub/NanopubUtils.java
+++ b/src/main/java/org/nanopub/NanopubUtils.java
@@ -13,8 +13,10 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.*;
 import org.eclipse.rdf4j.rio.*;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
+import org.nanopub.extra.services.SparqlSyntax;
 import org.nanopub.trusty.TempUriReplacer;
 import org.nanopub.trusty.TrustyNanopubUtils;
+import org.nanopub.vocabulary.KPXL_GRLC;
 import org.nanopub.vocabulary.NP;
 import org.nanopub.vocabulary.NPX;
 import org.nanopub.vocabulary.PAV;
@@ -120,6 +122,42 @@ public class NanopubUtils {
         Literal l = (Literal) st.getObject();
         return "Invalid value for datatype " + l.getDatatype().stringValue() + ": \"" + l.getLabel() +
                 "\" (as object of " + st.getPredicate().stringValue() + ")";
+    }
+
+    /**
+     * Returns the statements of the given Nanopub whose object is a SPARQL query, declared with
+     * {@link org.nanopub.vocabulary.KPXL_GRLC#SPARQL}, that does not parse, across all four graphs.
+     * <p>
+     * A nanopub cannot be edited after the fact, so a grlc query nanopub whose SPARQL is broken is
+     * broken permanently: it can never run. Such nanopubs are therefore refused by the signing and
+     * publishing steps, but ones published before that check exist in the wild and can still be loaded
+     * and read.
+     *
+     * @param nanopub the Nanopub to check
+     * @return the statements with an unparseable SPARQL query, in the order of {@link #getStatements(Nanopub)}
+     */
+    public static List<Statement> getInvalidSparqlStatements(Nanopub nanopub) {
+        List<Statement> invalid = new ArrayList<>();
+        for (Statement st : getStatements(nanopub)) {
+            if (!st.getPredicate().equals(KPXL_GRLC.SPARQL)) continue;
+            if (!(st.getObject() instanceof Literal l)) continue;
+            if (!SparqlSyntax.isValid(l.getLabel())) {
+                invalid.add(st);
+            }
+        }
+        return invalid;
+    }
+
+    /**
+     * Describes an unparseable SPARQL query as found by {@link #getInvalidSparqlStatements(Nanopub)}.
+     *
+     * @param st a statement whose object is a SPARQL query that does not parse
+     * @return a human-readable description of the syntax error
+     */
+    public static String describeInvalidSparql(Statement st) {
+        Literal l = (Literal) st.getObject();
+        return "Invalid SPARQL as object of " + st.getPredicate().stringValue() + ": " +
+                SparqlSyntax.getSyntaxError(l.getLabel());
     }
 
     private static List<Statement> getSortedList(Set<Statement> s) {

--- a/src/main/java/org/nanopub/extra/security/SignatureUtils.java
+++ b/src/main/java/org/nanopub/extra/security/SignatureUtils.java
@@ -156,6 +156,11 @@ public class SignatureUtils {
             throw new MalformedNanopubException("Nanopub has ill-typed literal(s) and cannot be signed: " +
                     NanopubUtils.describeIllTypedLiteral(illTyped.getFirst()));
         }
+        List<Statement> invalidSparql = NanopubUtils.getInvalidSparqlStatements(preNanopub);
+        if (!invalidSparql.isEmpty()) {
+            throw new MalformedNanopubException("Nanopub has invalid SPARQL and cannot be signed: " +
+                    NanopubUtils.describeInvalidSparql(invalidSparql.getFirst()));
+        }
 
         RdfFileContent r = new RdfFileContent(RDFFormat.TRIG);
         IRI npUri;

--- a/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
@@ -55,6 +55,7 @@ public class NanopubVerifier {
         checkExample();
         checkBlacklist();
         checkLiteralDatatypes();
+        checkSparqlSyntax();
 
         if (issues.isEmpty()) {
             logger.debug("Nanopub {} passed verification with no issues", nanopub.getUri());
@@ -110,6 +111,17 @@ public class NanopubVerifier {
     private void checkLiteralDatatypes() {
         for (Statement st : NanopubUtils.getIllTypedLiteralStatements(nanopub)) {
             issues.add(NanopubUtils.describeIllTypedLiteral(st));
+        }
+    }
+
+    /**
+     * Check that the SPARQL of a grlc query nanopub parses. Such nanopubs are refused by the signing
+     * and publishing steps, but ones published before that check exist in the wild: they can never be
+     * run, and the only remedy is publishing a corrected version.
+     */
+    private void checkSparqlSyntax() {
+        for (Statement st : NanopubUtils.getInvalidSparqlStatements(nanopub)) {
+            issues.add(NanopubUtils.describeInvalidSparql(st));
         }
     }
 

--- a/src/main/java/org/nanopub/extra/server/PublishNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/PublishNanopub.java
@@ -7,6 +7,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.eclipse.rdf4j.common.exception.RDF4JException;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
@@ -246,6 +247,15 @@ public class PublishNanopub extends CliRunner {
                 logger.warn("Strict mode: nanopub {} is not published", nanopub.getUri());
                 return null;
             }
+        }
+
+        List<Statement> invalidSparql = NanopubUtils.getInvalidSparqlStatements(nanopub);
+        if (!invalidSparql.isEmpty()) {
+            // A nanopub cannot be edited after the fact, so a query published with broken SPARQL can
+            // never run: publishing it is refused rather than warned about. This happens before any
+            // server is contacted.
+            throw new RuntimeException("Can't publish nanopublication with invalid SPARQL: " + nanopub.getUri() +
+                    ". " + NanopubUtils.describeInvalidSparql(invalidSparql.getFirst()));
         }
 
         if (registryInfo == null) {

--- a/src/main/java/org/nanopub/extra/services/GrlcQueryPattern.java
+++ b/src/main/java/org/nanopub/extra/services/GrlcQueryPattern.java
@@ -65,7 +65,7 @@ public class GrlcQueryPattern implements NanopubPattern {
      */
     @Override
     public URL getPatternInfoUrl() throws MalformedURLException, URISyntaxException {
-        return new URI("https://w3id.org/kpxl/grlc/").toURL();
+        return new URI(KPXL_GRLC.NAMESPACE).toURL();
     }
 
 }

--- a/src/main/java/org/nanopub/extra/services/GrlcQueryPattern.java
+++ b/src/main/java/org/nanopub/extra/services/GrlcQueryPattern.java
@@ -1,0 +1,71 @@
+package org.nanopub.extra.services;
+
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Statement;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubPattern;
+import org.nanopub.NanopubUtils;
+import org.nanopub.vocabulary.KPXL_GRLC;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.List;
+
+/**
+ * A nanopublication pattern for grlc query nanopublications, checking that their SPARQL parses.
+ * <p>
+ * A nanopublication cannot be edited after the fact, so a query whose SPARQL is broken is broken
+ * permanently: it can never run, and the only remedy is publishing a corrected version.
+ */
+public class GrlcQueryPattern implements NanopubPattern {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getName() {
+        return "grlc query nanopublication";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean appliesTo(Nanopub nanopub) {
+        for (Statement st : NanopubUtils.getStatements(nanopub)) {
+            if (st.getPredicate().equals(KPXL_GRLC.SPARQL) && st.getObject() instanceof Literal) return true;
+        }
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCorrectlyUsedBy(Nanopub nanopub) {
+        return NanopubUtils.getInvalidSparqlStatements(nanopub).isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getDescriptionFor(Nanopub nanopub) {
+        List<Statement> invalid = NanopubUtils.getInvalidSparqlStatements(nanopub);
+        if (invalid.isEmpty()) {
+            return "grlc query with valid SPARQL";
+        }
+        return NanopubUtils.describeInvalidSparql(invalid.getFirst());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URL getPatternInfoUrl() throws MalformedURLException, URISyntaxException {
+        return new URI("https://w3id.org/kpxl/grlc/").toURL();
+    }
+
+}

--- a/src/main/java/org/nanopub/extra/services/SparqlSyntax.java
+++ b/src/main/java/org/nanopub/extra/services/SparqlSyntax.java
@@ -1,0 +1,95 @@
+package org.nanopub.extra.services;
+
+import org.eclipse.rdf4j.query.MalformedQueryException;
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Checks SPARQL query strings for syntax errors, and describes what is wrong in terms the author of
+ * the query can act on.
+ * <p>
+ * The parser used here is the one {@link QueryTemplate} runs, so a query that passes this check is a
+ * query that can later be executed.
+ */
+public class SparqlSyntax {
+
+    private SparqlSyntax() {
+    }  // no instances allowed
+
+    private static final Pattern positionPattern = Pattern.compile("line (\\d+), column (\\d+)");
+
+    /**
+     * Checks whether the given string is a syntactically valid SPARQL query.
+     *
+     * @param sparql the query string to check
+     * @return true if the query parses
+     */
+    public static boolean isValid(String sparql) {
+        return getSyntaxError(sparql) == null;
+    }
+
+    /**
+     * Describes what keeps the given string from being a valid SPARQL query.
+     * <p>
+     * Where the parser points at a non-ASCII character, that character is named. Queries are more often
+     * broken by a character picked up on the way through a word processor or a web page than by a
+     * hand-written syntax error, and the parser reports such a character as a bare number, which leaves
+     * the author none the wiser: a no-break space looks exactly like the space it replaced.
+     *
+     * @param sparql the query string to check
+     * @return a description of the syntax error, or null if the query parses (or is null)
+     */
+    public static String getSyntaxError(String sparql) {
+        if (sparql == null) return null;
+        try {
+            new SPARQLParser().parseQuery(sparql, null);
+            return null;
+        } catch (MalformedQueryException ex) {
+            return describe(sparql, ex.getMessage());
+        }
+    }
+
+    private static String describe(String sparql, String parserMessage) {
+        String description = "This is not valid SPARQL. The SPARQL parser reports: " + summarize(parserMessage);
+        String character = describeCharacterAt(sparql, parserMessage);
+        if (character != null) {
+            description += " " + character;
+        }
+        return description;
+    }
+
+    /**
+     * Reduces the parser's report to its first line, which says what was encountered and where. What
+     * follows is the list of everything the parser would have accepted instead, which runs to dozens of
+     * lines and does not survive being quoted in an error message.
+     */
+    private static String summarize(String parserMessage) {
+        if (parserMessage == null) return "(no details given)";
+        String firstLine = parserMessage.split("\\R", 2)[0].replaceAll("\\s+", " ").trim();
+        return firstLine.replaceAll("[,.]+$", "") + ".";
+    }
+
+    /**
+     * Names the character the parser points at, if it is not an ASCII one. For ASCII characters the
+     * parser's own report already shows what is there.
+     */
+    private static String describeCharacterAt(String sparql, String parserMessage) {
+        if (parserMessage == null) return null;
+        Matcher m = positionPattern.matcher(parserMessage);
+        if (!m.find()) return null;
+        int line = Integer.parseInt(m.group(1));
+        int column = Integer.parseInt(m.group(2));
+        String[] lines = sparql.split("\\R", -1);
+        if (line < 1 || line > lines.length || column < 1 || column > lines[line - 1].length()) return null;
+        int codePoint = lines[line - 1].codePointAt(column - 1);
+        if (codePoint < 128) return null;
+        String name = Character.getName(codePoint);
+        return "The character in that position is " + String.format("U+%04X", codePoint) +
+                (name == null ? "" : " (" + name + ")") + ", which SPARQL doesn't allow there. " +
+                "Characters like this one tend to slip in when a query is copied from a word processor " +
+                "or a web page, and replacing them with their plain equivalents makes the query valid again.";
+    }
+
+}

--- a/src/test/java/org/nanopub/CheckNanopubTest.java
+++ b/src/test/java/org/nanopub/CheckNanopubTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.nanopub.utils.TestUtils;
+import org.nanopub.vocabulary.KPXL_GRLC;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -114,6 +115,63 @@ public class CheckNanopubTest {
         assertTrue(r.areAllTrusty());
         assertTrue(log.toString().contains("TRUSTY NANOPUB WITH ILL-TYPED LITERAL(S)"));
         assertTrue(log.toString().contains("Invalid value for datatype "));
+    }
+
+    @Test
+    void check_withInvalidSparqlInPlainNanopub_countsAsInvalid(@TempDir Path tmp) throws Exception {
+        File file = tmp.resolve("badsparql.trig").toFile();
+        writeNanopub(file, grlcQueryCreator("SELECT ?x WHERE {\u00A0?x ?y ?z }").finalizeNanopub());
+
+        ByteArrayOutputStream log = new ByteArrayOutputStream();
+        CheckNanopub checker = new CheckNanopub(List.of(file.getAbsolutePath()));
+        checker.setLogPrintStream(new PrintStream(log));
+
+        CheckNanopub.Report r = checker.check();
+
+        assertEquals(1, r.getInvalidCount());
+        assertFalse(r.areAllValid());
+    }
+
+    @Test
+    void check_withInvalidSparqlInTrustyNanopub_staysTrustyButWarns(@TempDir Path tmp) throws Exception {
+        // nanopubs like this exist in the wild: they cannot be edited, so they must still load
+        File file = tmp.resolve("trusty_badsparql.trig").toFile();
+        writeNanopub(file, grlcQueryCreator("SELECT ?x WHERE {\u00A0?x ?y ?z }").finalizeTrustyNanopub());
+
+        ByteArrayOutputStream log = new ByteArrayOutputStream();
+        CheckNanopub checker = new CheckNanopub(List.of(file.getAbsolutePath()));
+        checker.setLogPrintStream(new PrintStream(log));
+
+        CheckNanopub.Report r = checker.check();
+
+        assertTrue(r.areAllTrusty());
+        assertTrue(log.toString().contains("TRUSTY NANOPUB WITH INVALID SPARQL"));
+        assertTrue(log.toString().contains("U+00A0 (NO-BREAK SPACE)"));
+    }
+
+    @Test
+    void check_withValidSparqlInPlainNanopub_countsAsValid(@TempDir Path tmp) throws Exception {
+        File file = tmp.resolve("goodsparql.trig").toFile();
+        writeNanopub(file, grlcQueryCreator("SELECT ?x WHERE { ?x ?y ?z }").finalizeNanopub());
+
+        CheckNanopub checker = new CheckNanopub(List.of(file.getAbsolutePath()));
+        checker.setLogPrintStream(new PrintStream(new ByteArrayOutputStream()));
+
+        assertTrue(checker.check().areAllValid());
+    }
+
+    private static NanopubCreator grlcQueryCreator(String sparql) throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, TestUtils.vf.createLiteral(sparql));
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        return creator;
+    }
+
+    private static void writeNanopub(File file, Nanopub np) throws IOException {
+        try (OutputStream out = new FileOutputStream(file)) {
+            NanopubUtils.writeToStream(np, out, RDFFormat.TRIG);
+        }
     }
 
     @Test

--- a/src/test/java/org/nanopub/NanopubUtilsTest.java
+++ b/src/test/java/org/nanopub/NanopubUtilsTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import org.nanopub.trusty.TempUriReplacer;
 import org.nanopub.trusty.TrustyNanopubUtils;
 import org.nanopub.utils.TestUtils;
+import org.nanopub.vocabulary.KPXL_GRLC;
 import static org.nanopub.utils.TestUtils.anyIri;
 import static org.nanopub.utils.TestUtils.vf;
 import org.nanopub.vocabulary.NPX;
@@ -111,6 +112,34 @@ public class NanopubUtilsTest {
         creator.addPubinfoStatement(anyIri, anyIri);
 
         assertTrue(NanopubUtils.getIllTypedLiteralStatements(creator.finalizeNanopub()).isEmpty());
+    }
+
+    @Test
+    void getInvalidSparqlStatementsFindsOnlyTheBrokenQueries() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, vf.createLiteral("SELECT ?x WHERE { ?x ?y ?z }"));
+        creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, vf.createLiteral("SELECT ?x WHERE { ?x ?y }"));
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        Nanopub nanopub = creator.finalizeNanopub();
+
+        List<Statement> invalid = NanopubUtils.getInvalidSparqlStatements(nanopub);
+
+        assertEquals(1, invalid.size());
+        assertTrue(NanopubUtils.describeInvalidSparql(invalid.getFirst())
+                .startsWith("Invalid SPARQL as object of " + KPXL_GRLC.SPARQL.stringValue()));
+    }
+
+    @Test
+    void getInvalidSparqlStatementsIgnoresOtherPredicatesAndNonLiterals() throws MalformedNanopubException, NanopubAlreadyFinalizedException {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        // the same broken query text under a predicate that does not declare it as SPARQL
+        creator.addAssertionStatement(anyIri, anyIri, vf.createLiteral("SELECT ?x WHERE { ?x ?y }"));
+        creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, anyIri);
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+
+        assertTrue(NanopubUtils.getInvalidSparqlStatements(creator.finalizeNanopub()).isEmpty());
     }
 
     @Test

--- a/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/security/SignNanopubTest.java
@@ -37,6 +37,7 @@ import org.nanopub.testsuite.TestSuiteEntry;
 import org.nanopub.testsuite.TestSuiteSubfolder;
 import org.nanopub.testsuite.TransformTestCase;
 import org.nanopub.utils.TestUtils;
+import org.nanopub.vocabulary.KPXL_GRLC;
 import static org.nanopub.utils.TestUtils.anyIri;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,6 +202,33 @@ class SignNanopubTest {
 
         SignatureException ex = assertThrows(SignatureException.class, () -> SignNanopub.signAndTransform(np, context));
         assertTrue(ex.getMessage().contains("ill-typed literal(s) and cannot be signed"));
+    }
+
+    @Test
+    void refusesToSignNanopubWithInvalidSparql() throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, TestUtils.vf.createLiteral("SELECT ?x WHERE {\u00A0?x ?y ?z }"));
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        Nanopub np = creator.finalizeNanopub();
+
+        SignatureException ex = assertThrows(SignatureException.class,
+                () -> SignNanopub.signAndTransform(np, transformContext(false)));
+
+        assertTrue(ex.getMessage().contains("invalid SPARQL and cannot be signed"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("U+00A0 (NO-BREAK SPACE)"), ex.getMessage());
+    }
+
+    @Test
+    void signsNanopubWithValidSparql() throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, TestUtils.vf.createLiteral("SELECT ?x WHERE { ?x ?y ?z }"));
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+
+        Nanopub signed = SignNanopub.signAndTransform(creator.finalizeNanopub(), transformContext(false));
+
+        assertTrue(TrustyUriUtils.isPotentialTrustyUri(signed.getUri()));
     }
 
     // --------------------------------------------------------------- helpers

--- a/src/test/java/org/nanopub/extra/server/PublishNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/server/PublishNanopubTest.java
@@ -1,0 +1,35 @@
+package org.nanopub.extra.server;
+
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.utils.TestUtils;
+import org.nanopub.vocabulary.KPXL_GRLC;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.nanopub.utils.TestUtils.anyIri;
+
+class PublishNanopubTest {
+
+    private static Nanopub grlcQuery(String sparql) throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, TestUtils.vf.createLiteral(sparql));
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        return creator.finalizeTrustyNanopub();
+    }
+
+    @Test
+    void refusesToPublishANanopubWithInvalidSparql() throws Exception {
+        // no server is contacted: the refusal happens before the registry is looked up
+        Nanopub np = grlcQuery("SELECT ?x WHERE { ?x ?y ?z }");
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> new PublishNanopub().publishNanopub(np, "https://example.org/unreachable/"));
+
+        assertTrue(ex.getMessage().contains("Can't publish nanopublication with invalid SPARQL"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("U+00A0 (NO-BREAK SPACE)"), ex.getMessage());
+    }
+
+}

--- a/src/test/java/org/nanopub/extra/services/GrlcQueryPatternTest.java
+++ b/src/test/java/org/nanopub/extra/services/GrlcQueryPatternTest.java
@@ -1,0 +1,78 @@
+package org.nanopub.extra.services;
+
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.Test;
+import org.nanopub.Nanopub;
+import org.nanopub.NanopubCreator;
+import org.nanopub.NanopubPatterns;
+import org.nanopub.utils.TestUtils;
+import org.nanopub.vocabulary.KPXL_GRLC;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.nanopub.utils.TestUtils.anyIri;
+
+class GrlcQueryPatternTest {
+
+    private static final GrlcQueryPattern pattern = new GrlcQueryPattern();
+
+    private static Nanopub grlcQuery(String sparql) throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, RDF.TYPE, KPXL_GRLC.GRLC_QUERY);
+        if (sparql != null) {
+            creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, TestUtils.vf.createLiteral(sparql));
+        }
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        return creator.finalizeNanopub();
+    }
+
+    @Test
+    void appliesToANanopubWithASparqlLiteral() throws Exception {
+        assertTrue(pattern.appliesTo(grlcQuery("SELECT ?x WHERE { ?x ?y ?z }")));
+    }
+
+    @Test
+    void doesNotApplyToANanopubWithoutASparqlLiteral() throws Exception {
+        assertFalse(pattern.appliesTo(grlcQuery(null)));
+        assertFalse(pattern.appliesTo(TestUtils.createNanopub()));
+    }
+
+    @Test
+    void acceptsAQueryThatParses() throws Exception {
+        Nanopub np = grlcQuery("SELECT ?x WHERE { ?x ?y ?z }");
+
+        assertTrue(pattern.isCorrectlyUsedBy(np));
+        assertEquals("grlc query with valid SPARQL", pattern.getDescriptionFor(np));
+    }
+
+    @Test
+    void rejectsAQueryThatDoesNotParse() throws Exception {
+        Nanopub np = grlcQuery("SELECT ?x WHERE { ?x ?y }");
+
+        assertFalse(pattern.isCorrectlyUsedBy(np));
+        assertTrue(pattern.getDescriptionFor(np).contains("This is not valid SPARQL."), pattern.getDescriptionFor(np));
+    }
+
+    @Test
+    void namesAnInvisibleCharacterInTheDescription() throws Exception {
+        Nanopub np = grlcQuery("SELECT ?x WHERE {\u00A0?x ?y ?z }");
+
+        assertFalse(pattern.isCorrectlyUsedBy(np));
+        assertTrue(pattern.getDescriptionFor(np).contains("U+00A0 (NO-BREAK SPACE)"), pattern.getDescriptionFor(np));
+    }
+
+    @Test
+    void hasANameAndAnInfoUrl() throws Exception {
+        assertEquals("grlc query nanopublication", pattern.getName());
+        assertNotNull(pattern.getPatternInfoUrl());
+    }
+
+    @Test
+    void isRegistered() {
+        assertTrue(NanopubPatterns.getPatterns().stream().anyMatch(p -> p instanceof GrlcQueryPattern));
+    }
+
+}

--- a/src/test/java/org/nanopub/extra/services/SparqlSyntaxTest.java
+++ b/src/test/java/org/nanopub/extra/services/SparqlSyntaxTest.java
@@ -1,0 +1,75 @@
+package org.nanopub.extra.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SparqlSyntaxTest {
+
+    private static final String VALID = "SELECT ?x WHERE { ?x ?y ?z }";
+
+    @Test
+    void acceptsAValidQuery() {
+        assertTrue(SparqlSyntax.isValid(VALID));
+        assertNull(SparqlSyntax.getSyntaxError(VALID));
+    }
+
+    @Test
+    void acceptsAQueryWithPlaceholders() {
+        assertTrue(SparqlSyntax.isValid("SELECT ?x WHERE { ?x ?y ?_placeholder }"));
+    }
+
+    @Test
+    void rejectsAnEmptyQuery() {
+        assertFalse(SparqlSyntax.isValid(""));
+        assertTrue(SparqlSyntax.getSyntaxError("").startsWith("This is not valid SPARQL."));
+    }
+
+    @Test
+    void ignoresANullQuery() {
+        assertTrue(SparqlSyntax.isValid(null));
+        assertNull(SparqlSyntax.getSyntaxError(null));
+    }
+
+    @Test
+    void namesANoBreakSpace() {
+        String error = SparqlSyntax.getSyntaxError("SELECT ?x\nWHERE {\u00A0?x ?y ?z }");
+
+        assertNotNull(error);
+        assertTrue(error.contains("U+00A0 (NO-BREAK SPACE)"), error);
+        assertTrue(error.contains("line 2, column 8"), error);
+        assertTrue(error.contains("word processor"), error);
+    }
+
+    @Test
+    void namesATypographicQuote() {
+        String error = SparqlSyntax.getSyntaxError("SELECT ?x WHERE { ?x ?y “hello” }");
+
+        assertNotNull(error);
+        assertTrue(error.contains("U+201C (LEFT DOUBLE QUOTATION MARK)"), error);
+    }
+
+    @Test
+    void doesNotNameAnAsciiCharacter() {
+        // the parser's own report already shows what is there
+        String error = SparqlSyntax.getSyntaxError("SELECT ?x WHERE { ?x ?y }");
+
+        assertNotNull(error);
+        assertFalse(error.contains("The character in that position"), error);
+        assertTrue(error.contains("line 1, column 25"), error);
+    }
+
+    @Test
+    void keepsTheParserReportToASingleLine() {
+        // the parser follows its complaint with a list of everything it would have accepted instead,
+        // which runs to dozens of lines
+        String error = SparqlSyntax.getSyntaxError("SELECT ?x WHERE { ?x ?y }");
+
+        assertFalse(error.contains("\n"), error);
+        assertFalse(error.contains("Was expecting"), error);
+    }
+
+}


### PR DESCRIPTION
Closes #132

## The problem

A nanopublication can't be edited after the fact, so a grlc query nanopublication whose SPARQL doesn't parse is broken permanently: it can never run, and the only remedy is publishing a corrected version. Nothing in nanopub-java stopped such a nanopublication from being signed and published.

## What's added

**`SparqlSyntax`** (`org.nanopub.extra.services`) runs the same `SPARQLParser` that `QueryTemplate` uses, so a query that passes this check is one that can later be executed. `getSyntaxError` returns `null` or a diagnosis in plain words.

Where the parser points at a **non-ASCII** character, that character is named. These queries are more often broken by a character picked up on the way through a word processor or a web page than by a hand-written syntax error, and the parser reports such a character as a bare number, which leaves the author none the wiser — a no-break space looks exactly like the space it replaced:

```
This is not valid SPARQL. The SPARQL parser reports: Lexical error at line 2, column 8.
Encountered: '160' (160). The character in that position is U+00A0 (NO-BREAK SPACE), which
SPARQL doesn't allow there. Characters like this one tend to slip in when a query is copied
from a word processor or a web page, and replacing them with their plain equivalents makes
the query valid again.
```

For ASCII characters the parser's own report already shows what is there, so nothing is added. The parser's report is trimmed to its first line — what follows is the list of everything it would have accepted instead, which runs to dozens of lines and does not survive being quoted in an error message.

**`GrlcQueryPattern`**, registered in `NanopubPatterns`, puts the check into the ordinary validity story rather than making it a special case at one call site: `appliesTo` = the nanopublication has a `kpxl_grlc:sparql` literal, `isCorrectlyUsedBy` = it parses, `getDescriptionFor` = the diagnosis.

**`NanopubUtils.getInvalidSparqlStatements` / `describeInvalidSparql`** mirror the existing ill-typed-literal pair, so each call site is one line.

## Old nanopublications still load; new ones are refused

Nanopublications with broken SPARQL exist in the wild and cannot be fixed, so they must keep loading. The behaviour follows what ill-typed literals already do:

| | behaviour |
|---|---|
| Loading (`NanopubImpl`) | unchanged — existing broken query nanopublications load and read as before |
| `CheckNanopub`, **trusty** np | valid, with `WARNING: TRUSTY NANOPUB WITH INVALID SPARQL` |
| `CheckNanopub`, **plain** np | `INVALID NANOPUB` |
| `NanopubVerifier` | listed as an issue |
| **Signing** | `MalformedNanopubException` — refused |
| **Publishing** | `RuntimeException` — refused, before any server is contacted |

Verified end to end on a file with a real no-break space: it loads (7 statements), `np check` reports `INVALID NANOPUB` with the diagnosis, signing is refused, and the same nanopublication made trusty still checks out as trusty with only a warning.

### One judgment call worth a look

The publish refusal is unconditional, so re-publishing an *already published* nanopublication with broken SPARQL is refused too — mirroring and re-publish flows would hit this. Signing alone already stops anything new from getting out. If legacy re-publishing should keep working, drop the block in `PublishNanopub.publishNanopub`; the `NanopubVerifier` issue plus `--strict` still covers it.

## Tests

23 new tests, full suite 1209 passing:

- `SparqlSyntaxTest` (8) — valid queries and placeholders, empty and null input, naming a no-break space and a typographic quote, not naming ASCII characters, keeping the report to one line
- `GrlcQueryPatternTest` (7) — `appliesTo` / `isCorrectlyUsedBy` / `getDescriptionFor` / registration
- `PublishNanopubTest` (1) — publish refused, no network
- `NanopubUtilsTest` (+2), `SignNanopubTest` (+2), `CheckNanopubTest` (+3), including `check_withInvalidSparqlInTrustyNanopub_staysTrustyButWarns`, which pins the "existing ones must still load" requirement

## Related

The same gap exists in the other clients: Nanopublication/nanopub-py#266 and Nanopublication/nanopub-js#41. Nanodash does this on the form side in `SparqlSyntax` (knowledgepixels/nanodash#619, knowledgepixels/nanodash#617).

🤖 Generated with [Claude Code](https://claude.com/claude-code)