### PR TITLE
fix: blacklist http://schema.org/ instead of https://schema.org/

### DIFF
--- a/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
@@ -66,7 +66,7 @@ public class NanopubVerifier {
 
     /**
      * Check that no uri start with:
-     * - https://schema.org
+     * - http://schema.org/
      * - http://orcid.org
      */
     private void checkBlacklist() {
@@ -89,7 +89,7 @@ public class NanopubVerifier {
 
     private boolean uriIsOnBlacklist(Resource uri) {
         final List<String> BLACKLIST = Arrays.asList(
-                "https://schema.org",
+                "http://schema.org/",
                 "http://orcid.org",
                 "https://www.wikidata.org/entity/",
                 "https://www.wikidata.org/wiki/",


### PR DESCRIPTION
Closes #136.

Swaps the schema.org entry in the soft blacklist (`NanopubVerifier.uriIsOnBlacklist()`) from `https://schema.org` to `http://schema.org/`, so that `https://schema.org/` becomes the recommended namespace. The javadoc above `checkBlacklist()` is updated to match.

### Note for reviewers

This makes the library's own `SCHEMA` vocabulary class inconsistent with the verifier: `org.nanopub.vocabulary.SCHEMA.NAMESPACE` is still `http://schema.org/`, so `op/Import.java` passes `schema:description` / `isBasedOn` / `name` statements into pubinfo that the verifier will now flag.

Flipping that constant to `https://` isn't a free fix — the same IRIs are used to *match* incoming RO-Crate/CEDAR JSON-LD, which uses the `http://` forms — so it's left out of this PR and probably wants a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)