### PR TITLE
feat: allow ipfs:, ipns:, did: and at: URIs in nanopublications

### DIFF
--- a/src/main/java/org/nanopub/UriSchemes.java
+++ b/src/main/java/org/nanopub/UriSchemes.java
@@ -4,14 +4,13 @@ import java.util.Locale;
 import java.util.Set;
 
 /**
- * Defines which URI schemes are allowed at which position in a nanopublication.
+ * Defines which URI schemes are allowed in a nanopublication.
  * <p>
  * Nanopublications have historically been restricted to http(s) URIs by tooling convention, but the
  * nanopublication guidelines do not mandate this. Content-addressed and decentralized identifiers
- * ({@code ipfs:}, {@code ipns:}, {@code did:}, {@code at:}) are valid IRIs and are useful as
- * subjects and objects of assertions. They are meaningless as predicates, however, and the
- * nanopublication's own URI has to remain http(s) because that is what the trusty URI scheme
- * assumes.
+ * ({@code ipfs:}, {@code ipns:}, {@code did:}, {@code at:}) are valid IRIs and are useful to refer
+ * to from within a nanopublication. Allowing them is not an endorsement: it only means that
+ * nanopublications using them are not flagged as problematic.
  * <p>
  * This class is the single place where that policy is stated, so that downstream tools do not each
  * have to re-invent an ad-hoc {@code matches("https?://.+")} test.
@@ -21,68 +20,22 @@ import java.util.Set;
 public class UriSchemes {
 
     /**
-     * The position a URI occupies in a nanopublication, which determines the schemes allowed for it.
+     * The URI schemes allowed in a nanopublication, in any position.
      */
-    public enum Position {
-
-        /**
-         * The subject of a triple, in any of the four graphs.
-         */
-        SUBJECT,
-
-        /**
-         * The predicate of a triple, in any of the four graphs.
-         */
-        PREDICATE,
-
-        /**
-         * The object of a triple, in any of the four graphs. Only applies if the object is a URI.
-         */
-        OBJECT,
-
-        /**
-         * The nanopublication's own URI, or one of its four graph URIs.
-         */
-        NANOPUB_URI
-
-    }
-
-    /**
-     * The schemes allowed for predicates and for the nanopublication's own URI.
-     */
-    public static final Set<String> HTTP_SCHEMES = Set.of("http", "https");
-
-    /**
-     * The schemes allowed for subjects and objects.
-     */
-    public static final Set<String> RESOURCE_SCHEMES = Set.of("http", "https", "ipfs", "ipns", "did", "at");
+    public static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https", "ipfs", "ipns", "did", "at");
 
     private UriSchemes() {
     }  // no instances allowed
 
     /**
-     * Returns the schemes that are allowed at the given position.
+     * Checks whether the given URI uses one of the allowed schemes.
      *
-     * @param position the position the URI occupies
-     * @return an unmodifiable set of lower-case scheme names
+     * @param uri the URI to check
+     * @return true if the URI is absolute and its scheme is allowed
      */
-    public static Set<String> getAllowedSchemes(Position position) {
-        return switch (position) {
-            case SUBJECT, OBJECT -> RESOURCE_SCHEMES;
-            case PREDICATE, NANOPUB_URI -> HTTP_SCHEMES;
-        };
-    }
-
-    /**
-     * Checks whether the given URI uses a scheme that is allowed at the given position.
-     *
-     * @param uri      the URI to check
-     * @param position the position the URI occupies
-     * @return true if the URI is absolute and its scheme is allowed at that position
-     */
-    public static boolean isAllowedUriScheme(String uri, Position position) {
+    public static boolean isAllowedUriScheme(String uri) {
         String scheme = getScheme(uri);
-        return scheme != null && getAllowedSchemes(position).contains(scheme);
+        return scheme != null && ALLOWED_SCHEMES.contains(scheme);
     }
 
     /**

--- a/src/main/java/org/nanopub/UriSchemes.java
+++ b/src/main/java/org/nanopub/UriSchemes.java
@@ -1,0 +1,109 @@
+package org.nanopub;
+
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * Defines which URI schemes are allowed at which position in a nanopublication.
+ * <p>
+ * Nanopublications have historically been restricted to http(s) URIs by tooling convention, but the
+ * nanopublication guidelines do not mandate this. Content-addressed and decentralized identifiers
+ * ({@code ipfs:}, {@code ipns:}, {@code did:}, {@code at:}) are valid IRIs and are useful as
+ * subjects and objects of assertions. They are meaningless as predicates, however, and the
+ * nanopublication's own URI has to remain http(s) because that is what the trusty URI scheme
+ * assumes.
+ * <p>
+ * This class is the single place where that policy is stated, so that downstream tools do not each
+ * have to re-invent an ad-hoc {@code matches("https?://.+")} test.
+ *
+ * @author Tobias Kuhn
+ */
+public class UriSchemes {
+
+    /**
+     * The position a URI occupies in a nanopublication, which determines the schemes allowed for it.
+     */
+    public enum Position {
+
+        /**
+         * The subject of a triple, in any of the four graphs.
+         */
+        SUBJECT,
+
+        /**
+         * The predicate of a triple, in any of the four graphs.
+         */
+        PREDICATE,
+
+        /**
+         * The object of a triple, in any of the four graphs. Only applies if the object is a URI.
+         */
+        OBJECT,
+
+        /**
+         * The nanopublication's own URI, or one of its four graph URIs.
+         */
+        NANOPUB_URI
+
+    }
+
+    /**
+     * The schemes allowed for predicates and for the nanopublication's own URI.
+     */
+    public static final Set<String> HTTP_SCHEMES = Set.of("http", "https");
+
+    /**
+     * The schemes allowed for subjects and objects.
+     */
+    public static final Set<String> RESOURCE_SCHEMES = Set.of("http", "https", "ipfs", "ipns", "did", "at");
+
+    private UriSchemes() {
+    }  // no instances allowed
+
+    /**
+     * Returns the schemes that are allowed at the given position.
+     *
+     * @param position the position the URI occupies
+     * @return an unmodifiable set of lower-case scheme names
+     */
+    public static Set<String> getAllowedSchemes(Position position) {
+        return switch (position) {
+            case SUBJECT, OBJECT -> RESOURCE_SCHEMES;
+            case PREDICATE, NANOPUB_URI -> HTTP_SCHEMES;
+        };
+    }
+
+    /**
+     * Checks whether the given URI uses a scheme that is allowed at the given position.
+     *
+     * @param uri      the URI to check
+     * @param position the position the URI occupies
+     * @return true if the URI is absolute and its scheme is allowed at that position
+     */
+    public static boolean isAllowedUriScheme(String uri, Position position) {
+        String scheme = getScheme(uri);
+        return scheme != null && getAllowedSchemes(position).contains(scheme);
+    }
+
+    /**
+     * Extracts the scheme of an absolute URI, normalized to lower case. URI schemes are
+     * case-insensitive, and consist of a letter followed by letters, digits, {@code +}, {@code -}
+     * and {@code .} (RFC 3986).
+     *
+     * @param uri the URI to take the scheme from
+     * @return the lower-case scheme, or null if the given string is null or is not an absolute URI
+     */
+    public static String getScheme(String uri) {
+        if (uri == null) return null;
+        int colon = uri.indexOf(':');
+        if (colon < 1) return null;
+        for (int i = 0; i < colon; i++) {
+            char c = uri.charAt(i);
+            boolean valid = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                    (i > 0 && ((c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.'));
+            if (!valid) return null;
+        }
+        return uri.substring(0, colon).toLowerCase(Locale.ROOT);
+    }
+
+}

--- a/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
@@ -12,7 +12,6 @@ import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubUtils;
 import org.nanopub.SimpleTimestampPattern;
 import org.nanopub.UriSchemes;
-import org.nanopub.UriSchemes.Position;
 import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
@@ -170,27 +169,25 @@ public class NanopubVerifier {
     }
 
     /**
-     * Check that every URI uses a scheme that is allowed at the position it occupies. Subjects and
-     * objects may use content-addressed and decentralized identifier schemes next to http(s), while
-     * predicates and the nanopublication's own URI are restricted to http(s). See
-     * {@link UriSchemes}.
+     * Check that every URI uses one of the allowed schemes, which next to http(s) include the
+     * content-addressed and decentralized identifier schemes. See {@link UriSchemes}.
      */
     private void checkUriProtocol() {
-        checkUriScheme(nanopub.getUri(), Position.NANOPUB_URI);
+        checkUriScheme(nanopub.getUri());
         for (IRI graphUri : nanopub.getGraphUris()) {
-            checkUriScheme(graphUri, Position.NANOPUB_URI);
+            checkUriScheme(graphUri);
         }
         for (Statement st : getAllStatements()) {
-            checkUriScheme(st.getSubject(), Position.SUBJECT);
-            checkUriScheme(st.getPredicate(), Position.PREDICATE);
-            checkUriScheme(st.getObject(), Position.OBJECT);
+            checkUriScheme(st.getSubject());
+            checkUriScheme(st.getPredicate());
+            checkUriScheme(st.getObject());
         }
     }
 
-    private void checkUriScheme(Value value, Position position) {
+    private void checkUriScheme(Value value) {
         // Blank nodes have no scheme to check:
         if (!(value instanceof IRI)) return;
-        if (!UriSchemes.isAllowedUriScheme(value.stringValue(), position)) {
+        if (!UriSchemes.isAllowedUriScheme(value.stringValue())) {
             issues.add("Invalid URI protocol: " + value.stringValue());
         }
     }

--- a/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubVerifier.java
@@ -4,12 +4,15 @@ import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.jspecify.annotations.NonNull;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubImpl;
 import org.nanopub.NanopubUtils;
 import org.nanopub.SimpleTimestampPattern;
+import org.nanopub.UriSchemes;
+import org.nanopub.UriSchemes.Position;
 import org.nanopub.extra.security.MalformedCryptoElementException;
 import org.nanopub.extra.security.NanopubSignatureElement;
 import org.nanopub.extra.security.SignatureUtils;
@@ -166,19 +169,29 @@ public class NanopubVerifier {
         }
     }
 
+    /**
+     * Check that every URI uses a scheme that is allowed at the position it occupies. Subjects and
+     * objects may use content-addressed and decentralized identifier schemes next to http(s), while
+     * predicates and the nanopublication's own URI are restricted to http(s). See
+     * {@link UriSchemes}.
+     */
     private void checkUriProtocol() {
+        checkUriScheme(nanopub.getUri(), Position.NANOPUB_URI);
+        for (IRI graphUri : nanopub.getGraphUris()) {
+            checkUriScheme(graphUri, Position.NANOPUB_URI);
+        }
         for (Statement st : getAllStatements()) {
-            if (!isHttpOrHttps(st.getSubject())) {
-                issues.add("Invalid URI protocol: " + st.getSubject().stringValue());
-            }
-            if (!isHttpOrHttps(st.getPredicate())) {
-                issues.add("Invalid URI protocol: " + st.getPredicate().stringValue());
-            }
-            if (st.getObject() instanceof IRI) {
-                if (!isHttpOrHttps(((IRI) st.getObject()))) {
-                    issues.add("Invalid URI protocol: " + st.getObject().stringValue());
-                }
-            }
+            checkUriScheme(st.getSubject(), Position.SUBJECT);
+            checkUriScheme(st.getPredicate(), Position.PREDICATE);
+            checkUriScheme(st.getObject(), Position.OBJECT);
+        }
+    }
+
+    private void checkUriScheme(Value value, Position position) {
+        // Blank nodes have no scheme to check:
+        if (!(value instanceof IRI)) return;
+        if (!UriSchemes.isAllowedUriScheme(value.stringValue(), position)) {
+            issues.add("Invalid URI protocol: " + value.stringValue());
         }
     }
 
@@ -189,10 +202,6 @@ public class NanopubVerifier {
         allStatements.addAll(nanopub.getProvenance());
         allStatements.addAll(nanopub.getPubinfo());
         return allStatements;
-    }
-
-    private boolean isHttpOrHttps(Resource uri) {
-        return uri.stringValue().startsWith("https://") || uri.stringValue().startsWith("http://");
     }
 
     /**

--- a/src/test/java/org/nanopub/UriSchemesTest.java
+++ b/src/test/java/org/nanopub/UriSchemesTest.java
@@ -1,7 +1,6 @@
 package org.nanopub;
 
 import org.junit.jupiter.api.Test;
-import org.nanopub.UriSchemes.Position;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -65,15 +64,13 @@ class UriSchemesTest {
     // -- isAllowedUriScheme --
 
     @Test
-    void isAllowedUriScheme_httpUri_allowedEverywhere() {
-        for (Position position : Position.values()) {
-            assertTrue(UriSchemes.isAllowedUriScheme("https://example.org/thing", position), position.name());
-            assertTrue(UriSchemes.isAllowedUriScheme("http://example.org/thing", position), position.name());
-        }
+    void isAllowedUriScheme_httpUri_isAllowed() {
+        assertTrue(UriSchemes.isAllowedUriScheme("https://example.org/thing"));
+        assertTrue(UriSchemes.isAllowedUriScheme("http://example.org/thing"));
     }
 
     @Test
-    void isAllowedUriScheme_decentralizedUri_allowedForSubjectAndObject() {
+    void isAllowedUriScheme_decentralizedUri_isAllowed() {
         for (String uri : new String[]{
                 "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
                 "ipns://k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8",
@@ -82,48 +79,35 @@ class UriSchemesTest {
                 "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
                 "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.feed.post/3juvq5gxvgt2b",
         }) {
-            assertTrue(UriSchemes.isAllowedUriScheme(uri, Position.SUBJECT), uri);
-            assertTrue(UriSchemes.isAllowedUriScheme(uri, Position.OBJECT), uri);
-            assertFalse(UriSchemes.isAllowedUriScheme(uri, Position.PREDICATE), uri);
-            assertFalse(UriSchemes.isAllowedUriScheme(uri, Position.NANOPUB_URI), uri);
+            assertTrue(UriSchemes.isAllowedUriScheme(uri), uri);
         }
     }
 
     @Test
-    void isAllowedUriScheme_unknownScheme_notAllowedAnywhere() {
-        for (Position position : Position.values()) {
-            assertFalse(UriSchemes.isAllowedUriScheme("ftp://example.org/thing", position), position.name());
-            assertFalse(UriSchemes.isAllowedUriScheme("urn:uuid:1b0e6d5c-1e5b-4a2f-9f4a-3f4e9a5b6c7d", position), position.name());
-        }
+    void isAllowedUriScheme_schemeIsCaseInsensitive_isAllowed() {
+        assertTrue(UriSchemes.isAllowedUriScheme("DID:plc:ewvi7nxzyoun6zhxrhs64oiz"));
     }
 
     @Test
-    void isAllowedUriScheme_relativeUri_notAllowedAnywhere() {
-        for (Position position : Position.values()) {
-            assertFalse(UriSchemes.isAllowedUriScheme("example.org/thing", position), position.name());
-        }
+    void isAllowedUriScheme_unknownScheme_isNotAllowed() {
+        assertFalse(UriSchemes.isAllowedUriScheme("ftp://example.org/thing"));
+        assertFalse(UriSchemes.isAllowedUriScheme("urn:uuid:1b0e6d5c-1e5b-4a2f-9f4a-3f4e9a5b6c7d"));
     }
 
     @Test
-    void isAllowedUriScheme_null_notAllowedAnywhere() {
-        for (Position position : Position.values()) {
-            assertFalse(UriSchemes.isAllowedUriScheme(null, position), position.name());
-        }
-    }
-
-    // -- getAllowedSchemes --
-
-    @Test
-    void getAllowedSchemes_predicateAndNanopubUri_areHttpOnly() {
-        assertEquals(UriSchemes.HTTP_SCHEMES, UriSchemes.getAllowedSchemes(Position.PREDICATE));
-        assertEquals(UriSchemes.HTTP_SCHEMES, UriSchemes.getAllowedSchemes(Position.NANOPUB_URI));
+    void isAllowedUriScheme_schemeLookalike_isNotAllowed() {
+        // must not be treated as a "did:" URI by prefix matching
+        assertFalse(UriSchemes.isAllowedUriScheme("didsomething://example.org/thing"));
     }
 
     @Test
-    void getAllowedSchemes_subjectAndObject_areTheWiderSet() {
-        assertEquals(UriSchemes.RESOURCE_SCHEMES, UriSchemes.getAllowedSchemes(Position.SUBJECT));
-        assertEquals(UriSchemes.RESOURCE_SCHEMES, UriSchemes.getAllowedSchemes(Position.OBJECT));
-        assertTrue(UriSchemes.RESOURCE_SCHEMES.containsAll(UriSchemes.HTTP_SCHEMES));
+    void isAllowedUriScheme_relativeUri_isNotAllowed() {
+        assertFalse(UriSchemes.isAllowedUriScheme("example.org/thing"));
+    }
+
+    @Test
+    void isAllowedUriScheme_null_isNotAllowed() {
+        assertFalse(UriSchemes.isAllowedUriScheme(null));
     }
 
 }

--- a/src/test/java/org/nanopub/UriSchemesTest.java
+++ b/src/test/java/org/nanopub/UriSchemesTest.java
@@ -1,0 +1,129 @@
+package org.nanopub;
+
+import org.junit.jupiter.api.Test;
+import org.nanopub.UriSchemes.Position;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UriSchemesTest {
+
+    // -- getScheme --
+
+    @Test
+    void getScheme_httpUri_returnsScheme() {
+        assertEquals("https", UriSchemes.getScheme("https://example.org/thing"));
+        assertEquals("http", UriSchemes.getScheme("http://example.org/thing"));
+    }
+
+    @Test
+    void getScheme_opaqueUri_returnsScheme() {
+        assertEquals("did", UriSchemes.getScheme("did:plc:ewvi7nxzyoun6zhxrhs64oiz"));
+    }
+
+    @Test
+    void getScheme_upperCaseScheme_returnsLowerCase() {
+        assertEquals("https", UriSchemes.getScheme("HTTPS://example.org/thing"));
+    }
+
+    @Test
+    void getScheme_schemeWithSpecialCharacters_returnsScheme() {
+        assertEquals("view-source", UriSchemes.getScheme("view-source:http://example.org/"));
+        assertEquals("a+b.c9", UriSchemes.getScheme("a+b.c9:rest"));
+    }
+
+    @Test
+    void getScheme_noColon_returnsNull() {
+        assertNull(UriSchemes.getScheme("example.org/thing"));
+    }
+
+    @Test
+    void getScheme_emptyScheme_returnsNull() {
+        assertNull(UriSchemes.getScheme(":relative"));
+    }
+
+    @Test
+    void getScheme_schemeStartingWithDigit_returnsNull() {
+        assertNull(UriSchemes.getScheme("1http://example.org/"));
+    }
+
+    @Test
+    void getScheme_invalidCharacterInScheme_returnsNull() {
+        assertNull(UriSchemes.getScheme("ht tp://example.org/"));
+        assertNull(UriSchemes.getScheme("http_s://example.org/"));
+    }
+
+    @Test
+    void getScheme_null_returnsNull() {
+        assertNull(UriSchemes.getScheme(null));
+    }
+
+    @Test
+    void getScheme_emptyString_returnsNull() {
+        assertNull(UriSchemes.getScheme(""));
+    }
+
+    // -- isAllowedUriScheme --
+
+    @Test
+    void isAllowedUriScheme_httpUri_allowedEverywhere() {
+        for (Position position : Position.values()) {
+            assertTrue(UriSchemes.isAllowedUriScheme("https://example.org/thing", position), position.name());
+            assertTrue(UriSchemes.isAllowedUriScheme("http://example.org/thing", position), position.name());
+        }
+    }
+
+    @Test
+    void isAllowedUriScheme_decentralizedUri_allowedForSubjectAndObject() {
+        for (String uri : new String[]{
+                "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+                "ipns://k51qzi5uqu5dlvj2baxnqndepeb86cbk3ng7n3i46uzyxzyqj2xjonzllnv0v8",
+                "did:plc:ewvi7nxzyoun6zhxrhs64oiz",
+                "did:web:example.org",
+                "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
+                "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.feed.post/3juvq5gxvgt2b",
+        }) {
+            assertTrue(UriSchemes.isAllowedUriScheme(uri, Position.SUBJECT), uri);
+            assertTrue(UriSchemes.isAllowedUriScheme(uri, Position.OBJECT), uri);
+            assertFalse(UriSchemes.isAllowedUriScheme(uri, Position.PREDICATE), uri);
+            assertFalse(UriSchemes.isAllowedUriScheme(uri, Position.NANOPUB_URI), uri);
+        }
+    }
+
+    @Test
+    void isAllowedUriScheme_unknownScheme_notAllowedAnywhere() {
+        for (Position position : Position.values()) {
+            assertFalse(UriSchemes.isAllowedUriScheme("ftp://example.org/thing", position), position.name());
+            assertFalse(UriSchemes.isAllowedUriScheme("urn:uuid:1b0e6d5c-1e5b-4a2f-9f4a-3f4e9a5b6c7d", position), position.name());
+        }
+    }
+
+    @Test
+    void isAllowedUriScheme_relativeUri_notAllowedAnywhere() {
+        for (Position position : Position.values()) {
+            assertFalse(UriSchemes.isAllowedUriScheme("example.org/thing", position), position.name());
+        }
+    }
+
+    @Test
+    void isAllowedUriScheme_null_notAllowedAnywhere() {
+        for (Position position : Position.values()) {
+            assertFalse(UriSchemes.isAllowedUriScheme(null, position), position.name());
+        }
+    }
+
+    // -- getAllowedSchemes --
+
+    @Test
+    void getAllowedSchemes_predicateAndNanopubUri_areHttpOnly() {
+        assertEquals(UriSchemes.HTTP_SCHEMES, UriSchemes.getAllowedSchemes(Position.PREDICATE));
+        assertEquals(UriSchemes.HTTP_SCHEMES, UriSchemes.getAllowedSchemes(Position.NANOPUB_URI));
+    }
+
+    @Test
+    void getAllowedSchemes_subjectAndObject_areTheWiderSet() {
+        assertEquals(UriSchemes.RESOURCE_SCHEMES, UriSchemes.getAllowedSchemes(Position.SUBJECT));
+        assertEquals(UriSchemes.RESOURCE_SCHEMES, UriSchemes.getAllowedSchemes(Position.OBJECT));
+        assertTrue(UriSchemes.RESOURCE_SCHEMES.containsAll(UriSchemes.HTTP_SCHEMES));
+    }
+
+}

--- a/src/test/java/org/nanopub/extra/server/NanopubVerifierTest.java
+++ b/src/test/java/org/nanopub/extra/server/NanopubVerifierTest.java
@@ -319,7 +319,7 @@ class NanopubVerifierTest {
     }
 
     @Test
-    void checkUriProtocol_decentralizedPredicate_reportsProblem() throws Exception {
+    void checkUriProtocol_decentralizedPredicate_noProtocolProblem() throws Exception {
         IRI did = vf.createIRI("did:plc:ewvi7nxzyoun6zhxrhs64oiz");
         NanopubCreator c = baseCreator();
         c.addAssertionStatement(anyIri, did, anyIri);
@@ -327,7 +327,7 @@ class NanopubVerifierTest {
 
         NanopubVerifier verifier = new NanopubVerifier(np);
         verifier.verify();
-        assertTrue(verifier.getIssues().contains("Invalid URI protocol: " + did.stringValue()));
+        assertTrue(verifier.getIssues().stream().noneMatch(s -> s.startsWith("Invalid URI protocol:")));
     }
 
     @Test
@@ -343,8 +343,8 @@ class NanopubVerifierTest {
     }
 
     @Test
-    void checkUriProtocol_nonHttpNanopubUri_reportsProblem() throws Exception {
-        String uri = "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    void checkUriProtocol_unknownSchemeNanopubUri_reportsProblem() throws Exception {
+        String uri = "ftp://example.org/nanopub";
         NanopubCreator c = new NanopubCreator(vf.createIRI(uri));
         c.addAssertionStatement(anyIri, anyIri, anyIri);
         c.addProvenanceStatement(anyIri, anyIri);

--- a/src/test/java/org/nanopub/extra/server/NanopubVerifierTest.java
+++ b/src/test/java/org/nanopub/extra/server/NanopubVerifierTest.java
@@ -292,6 +292,70 @@ class NanopubVerifierTest {
         assertTrue(verifier.getIssues().stream().anyMatch(s -> s.startsWith("Byte count exceeds maximum of 10MB")));
     }
 
+    // -- checkUriProtocol --
+
+    @Test
+    void checkUriProtocol_httpUris_noProtocolProblem() throws Exception {
+        Nanopub np = baseCreator().finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().stream().noneMatch(s -> s.startsWith("Invalid URI protocol:")));
+    }
+
+    @Test
+    void checkUriProtocol_decentralizedSubjectsAndObjects_noProtocolProblem() throws Exception {
+        IRI cid = vf.createIRI("ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi");
+        IRI did = vf.createIRI("did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+        IRI atUri = vf.createIRI("at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/app.bsky.feed.post/3juvq5gxvgt2b");
+        NanopubCreator c = baseCreator();
+        c.addAssertionStatement(cid, anyIri, did);
+        c.addAssertionStatement(did, anyIri, atUri);
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().stream().noneMatch(s -> s.startsWith("Invalid URI protocol:")));
+    }
+
+    @Test
+    void checkUriProtocol_decentralizedPredicate_reportsProblem() throws Exception {
+        IRI did = vf.createIRI("did:plc:ewvi7nxzyoun6zhxrhs64oiz");
+        NanopubCreator c = baseCreator();
+        c.addAssertionStatement(anyIri, did, anyIri);
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().contains("Invalid URI protocol: " + did.stringValue()));
+    }
+
+    @Test
+    void checkUriProtocol_unknownSchemeObject_reportsProblem() throws Exception {
+        IRI ftpUri = vf.createIRI("ftp://example.org/data.zip");
+        NanopubCreator c = baseCreator();
+        c.addAssertionStatement(anyIri, anyIri, ftpUri);
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().contains("Invalid URI protocol: " + ftpUri.stringValue()));
+    }
+
+    @Test
+    void checkUriProtocol_nonHttpNanopubUri_reportsProblem() throws Exception {
+        String uri = "ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+        NanopubCreator c = new NanopubCreator(vf.createIRI(uri));
+        c.addAssertionStatement(anyIri, anyIri, anyIri);
+        c.addProvenanceStatement(anyIri, anyIri);
+        c.addPubinfoStatement(anyIri, anyIri);
+        Nanopub np = c.finalizeNanopub();
+
+        NanopubVerifier verifier = new NanopubVerifier(np);
+        verifier.verify();
+        assertTrue(verifier.getIssues().contains("Invalid URI protocol: " + uri));
+    }
+
     // -- checkLiteralDatatypes --
 
     @Test


### PR DESCRIPTION
Closes #138.

Nanopubs could not reference resources identified by non-http(s) URI schemes, even though those are valid RDF and useful: content-addressed data (`ipfs:`, `ipns:`) and decentralized identifiers (`did:`, `at:`). `NanopubVerifier.checkUriProtocol()` was the only place enforcing the http(s)-only rule — everything else in the library is already permissive, and it is not called from nanopub-registry, nanopub-query or Nanodash.

Allowing these schemes is not an endorsement of them. It only means the verifier does not flag nanopublications that use them.

## What changed

**New `org.nanopub.UriSchemes`** — the shared helper from point 3 of the issue. Downstream tools can use this instead of each re-inventing an ad-hoc `matches("https?://.+")` test for "is this a URI":

- `ALLOWED_SCHEMES` — `http`, `https`, `ipfs`, `ipns`, `did`, `at`.
- `isAllowedUriScheme(String)` — the main entry point.
- `getScheme(String)` — RFC 3986 scheme extraction, lower-cased. Returns `null` for relative URIs, empty schemes, schemes starting with a digit, and invalid scheme characters. Deliberately not prefix matching, so `didsomething://…` is not mistaken for a DID.

The allowlist applies uniformly, in every position. The issue proposed restricting predicates and the nanopublication's own URI to http(s), but since the point is only to stop objecting rather than to actively support these schemes, there is no reason to permit a scheme in one position and prohibit it in another. That also keeps the helper free of a `Position` parameter every caller would have to pass and none would act on.

**`NanopubVerifier.checkUriProtocol()`** now uses the allowlist, and covers `nanopub.getUri()` and `nanopub.getGraphUris()` next to the statements. `isHttpOrHttps` is gone.

## Note

The new `checkUriScheme(Value)` returns early for non-IRI values. This fixes a pre-existing false positive: `isHttpOrHttps` took a `Resource`, so a blank-node subject was reported as `Invalid URI protocol: <node-id>`.

## Tests

16 in a new `UriSchemesTest`; 5 added to `NanopubVerifierTest` (http-only baseline, ipfs/did/at as subjects and objects, `did:` predicate accepted, `ftp:` object rejected, `ftp:` nanopub URI rejected). Full suite passes: 1208 tests, 0 failures.

## Follow-up

knowledgepixels/nanodash#655 — ~30 sites that would consume `UriSchemes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
