### PR TITLE
test(fdo): make the test keys in a temp dir, not in ~/.nanopub

### DIFF
--- a/src/test/java/org/nanopub/fdo/FdoRecordTest.java
+++ b/src/test/java/org/nanopub/fdo/FdoRecordTest.java
@@ -1,6 +1,5 @@
 package org.nanopub.fdo;
 
-import org.apache.commons.io.FileUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.util.Values;
@@ -11,6 +10,7 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
 import org.nanopub.*;
 import org.nanopub.extra.security.*;
@@ -21,8 +21,9 @@ import org.nanopub.vocabulary.FDOF;
 import org.nanopub.vocabulary.HDL;
 import org.nanopub.vocabulary.NPX;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -39,22 +40,28 @@ import static org.nanopub.utils.TestUtils.vf;
 
 class FdoRecordTest {
 
-    private static final String TEST_KEY_PATH = "~/.nanopub/testkey/";
     private static final String TEST_KEY_NAME = "id";
-    private static final String testKeysDirPath = SignatureUtils.getFullFilePath(TEST_KEY_PATH);
+
+    /**
+     * Where this test's keys are made. A directory of its own, per run: ~/.nanopub is
+     * where the person running the tests keeps their own signing key and profile, and a
+     * test suite has no business writing there.
+     */
+    @TempDir
+    private static Path testKeysDir;
 
     private static MockedStatic<TransformContext> transformContextMock;
 
     @BeforeAll
     static void setUp() throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
-        File testKeysDir = new File(testKeysDirPath);
-        testKeysDir.mkdirs();
-        MakeKeys.make(testKeysDirPath + TEST_KEY_NAME, SignatureAlgorithm.RSA);
-        assertTrue(new File(testKeysDirPath + TEST_KEY_NAME + "_" + SignatureAlgorithm.RSA.name().toLowerCase()).exists());
-        assertTrue(new File(testKeysDirPath + TEST_KEY_NAME + "_" + SignatureAlgorithm.RSA.name().toLowerCase() + ".pub").exists());
+        String keyFilePrefix = testKeysDir.resolve(TEST_KEY_NAME).toString();
+        MakeKeys.make(keyFilePrefix, RSA);
+        String privateKeyFile = keyFilePrefix + "_" + RSA.name().toLowerCase();
+        assertTrue(Files.exists(Path.of(privateKeyFile)));
+        assertTrue(Files.exists(Path.of(privateKeyFile + ".pub")));
 
         // mock TransformContext.makeDefault() to get test keys
-        KeyPair key = SignNanopub.loadKey(TEST_KEY_PATH + "/id_rsa", RSA);
+        KeyPair key = SignNanopub.loadKey(privateKeyFile, RSA);
 
         TransformContext testTC = new TransformContext(RSA, key, null, false, false, false);
         transformContextMock = mockStatic(TransformContext.class, CALLS_REAL_METHODS);
@@ -65,15 +72,11 @@ class FdoRecordTest {
     }
 
     @AfterAll
-    static void tearDown() throws IOException {
+    static void tearDown() {
         if (transformContextMock != null) {
             transformContextMock.close();
             transformContextMock = null;
         }
-
-        File testKeysDir = new File(testKeysDirPath);
-        FileUtils.deleteDirectory(testKeysDir);
-        assertFalse(testKeysDir.exists());
     }
 
 


### PR DESCRIPTION
Closes #140.

`FdoRecordTest` created `~/.nanopub/testkey/`, generated an RSA key pair there, and deleted the directory again when the class was done. `~/.nanopub` is where the person running the tests keeps their own signing key and profile, so a test suite has no business writing there, even transiently.

Nothing was destroyed by it — the real `id_rsa` and `profile.yaml` were never touched, and `MakeKeys.make` throws `FileAlreadyExistsException` rather than overwriting a key that is already there. What was left was still worth removing:

- `FileUtils.deleteDirectory` took `~/.nanopub/testkey` and everything in it, whatever that was;
- a run that never reached `@AfterAll` — a killed JVM, a crash, ctrl-C — left a generated private key behind in the home directory;
- two runs of the class at once, or a second run after residue was left, collided on the key file;
- it assumed a writable home directory, which not every CI or container setup has.

## The change

```java
@TempDir
private static Path testKeysDir;
```

A JUnit `@TempDir` removes the hazard and the cleanup along with it: the directory is per-run, JUnit removes it whether or not `@AfterAll` is reached, and concurrent runs cannot collide. `tearDown` is left with only the Mockito static mock to close, and `commons-io` and `java.io.File` are no longer needed in this test.

One test file, +18 −15.

## Verification

Watching the mtime of `~/.nanopub` across a run, which is how the problem was found in the first place:

| run | `~/.nanopub` mtime before | after |
| --- | --- | --- |
| `FdoRecordTest` (21 tests, all pass) | `1787913696` | `1787913696` — untouched |
| full suite (1237 tests, 0 failures) | `1787913696` | `1787913696` — untouched |

Before the change, running just that class moved the directory's mtime every time, from `testkey` being created inside it and deleted again.

The full-suite figure is worth having beyond this fix: it confirms that nothing else in the suite writes to the home directory either. `MakeKeysTest` writes into the test-classes directory, `SignatureUtilsTest` only asserts on `~` expansion, `UsageExamples.createKey()` is not a JUnit test and Surefire never runs it, and `ServerIterator.writeCachedServers` is only reachable from `FetchIndex`, which no test exercises.

## The other clients

The same class of problem, tracked per client:

- Nanopublication/nanopub-py#269 — destructive there: on a machine with no `~/.nanopub` yet, the Python suite writes real RSA keys into it, and one test copies its fixtures over `id_rsa`.
- nanopub-js — not affected. No home-directory access and no profile file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSAawRfUm4Au1UkejyNKY1
