### PR TITLE
feat: allow protected nanopubs to be published to local registry instances

### DIFF
--- a/src/main/java/org/nanopub/extra/server/PublishNanopub.java
+++ b/src/main/java/org/nanopub/extra/server/PublishNanopub.java
@@ -270,13 +270,21 @@ public class PublishNanopub extends CliRunner {
         }
         artifactCode = ArtifactCode.of(TrustyUriUtils.getArtifactCode(nanopub.getUri().toString()));
         reportProgress("Trying to publish nanopub: " + artifactCode);
-        if (NanopubServerUtils.isProtectedNanopub(nanopub)) {
-            throw new RuntimeException("Can't publish protected nanopublication: " + artifactCode);
-        }
+        boolean isProtected = NanopubServerUtils.isProtectedNanopub(nanopub);
+        boolean foundEligibleRegistry = false;
         while (registryInfo != null) {
             String url = registryInfo.getUrl();
 
             // TODO Check here whether nanopub type is covered at given registry.
+
+            if (isProtected && !registryInfo.isLocalInstance()) {
+                // Only local instances accept protected nanopubs; public registries would reject this.
+                logger.debug("Skipping {} for protected nanopub {}: not a local instance", url, artifactCode);
+                reportProgress("Skipping server (not a local instance): " + url);
+                registryInfo = serverIterator.next();
+                continue;
+            }
+            foundEligibleRegistry = true;
 
             reportProgress("Trying server: " + url);
             try {
@@ -295,6 +303,11 @@ public class PublishNanopub extends CliRunner {
             registryInfo = serverIterator.next();
         }
         registryInfo = null;
+        if (isProtected && !foundEligibleRegistry) {
+            throw new RuntimeException("Can't publish protected nanopublication: " + artifactCode +
+                                       ". None of the available registries is a local instance, " +
+                                       "and only local instances accept protected nanopublications.");
+        }
         if (dryRun) {
             System.out.println("Nanopub NOT published: --dry-run, np-uri=" + nanopub.getUri());
             return null;

--- a/src/main/java/org/nanopub/extra/server/RegistryInfo.java
+++ b/src/main/java/org/nanopub/extra/server/RegistryInfo.java
@@ -15,6 +15,13 @@ import java.nio.charset.StandardCharsets;
 public class RegistryInfo implements Serializable {
 
     /**
+     * Pinned to the value the JVM computed for this class before the
+     * isLocalInstance/isTestInstance/registryVersion fields were added, so that
+     * registry lists cached by earlier versions remain readable.
+     */
+    private static final long serialVersionUID = -8285437338229536648L;
+
+    /**
      * Exception class for handling errors related to loading registry information.
      */
     public static class RegistryInfoException extends Exception {
@@ -88,6 +95,11 @@ public class RegistryInfo implements Serializable {
     protected Long accountCount;
     protected Long nanopubCount;
     protected Long loadCounter;
+    protected String registryVersion;
+    protected Boolean isLocalInstance;
+    protected Boolean isTestInstance;
+    protected Boolean optionalLoadEnabled;
+    protected Boolean trustCalculationEnabled;
 
     /**
      * Returns the URL of the nanopub registry server.
@@ -222,6 +234,56 @@ public class RegistryInfo implements Serializable {
      */
     public Long getLoadCounter() {
         return loadCounter;
+    }
+
+    /**
+     * Returns the version of the registry software the server is running.
+     *
+     * @return the registry version, or null if the server does not report one
+     */
+    public String getRegistryVersion() {
+        return registryVersion;
+    }
+
+    /**
+     * Returns whether the registry declares itself a local instance. Local instances accept
+     * protected nanopublications, whereas public registries reject them.
+     *
+     * @return true if the registry reports itself as a local instance; false also if the server
+     * does not report the field at all, as is the case for registries older than version 1.12.0
+     */
+    public boolean isLocalInstance() {
+        return Boolean.TRUE.equals(isLocalInstance);
+    }
+
+    /**
+     * Returns whether the registry declares itself a test instance.
+     *
+     * @return true if the registry reports itself as a test instance; false also if the server
+     * does not report the field at all
+     */
+    public boolean isTestInstance() {
+        return Boolean.TRUE.equals(isTestInstance);
+    }
+
+    /**
+     * Returns whether the registry has optional loading enabled.
+     *
+     * @return true if the registry reports optional loading as enabled; false also if the server
+     * does not report the field at all
+     */
+    public boolean isOptionalLoadEnabled() {
+        return Boolean.TRUE.equals(optionalLoadEnabled);
+    }
+
+    /**
+     * Returns whether the registry has trust calculation enabled.
+     *
+     * @return true if the registry reports trust calculation as enabled; false also if the server
+     * does not report the field at all
+     */
+    public boolean isTrustCalculationEnabled() {
+        return Boolean.TRUE.equals(trustCalculationEnabled);
     }
 
     /**

--- a/src/test/java/org/nanopub/extra/server/PublishNanopubTest.java
+++ b/src/test/java/org/nanopub/extra/server/PublishNanopubTest.java
@@ -1,20 +1,99 @@
 package org.nanopub.extra.server;
 
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.nanopub.Nanopub;
 import org.nanopub.NanopubCreator;
+import org.nanopub.NanopubUtils;
 import org.nanopub.utils.TestUtils;
 import org.nanopub.vocabulary.KPXL_GRLC;
+import org.nanopub.vocabulary.NPX;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 import static org.nanopub.utils.TestUtils.anyIri;
 
 class PublishNanopubTest {
 
+    private static final String LOCAL_REGISTRY_URL = "https://local-registry.example/";
+    private static final String PUBLIC_REGISTRY_URL = "https://public-registry.example/";
+
+    private MockedStatic<NanopubUtils> mockStatic;
+    private CloseableHttpClient mockHttpClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        clearRegistryInfoCache();
+        mockHttpClient = mock(CloseableHttpClient.class);
+        mockStatic = mockStatic(NanopubUtils.class, CALLS_REAL_METHODS);
+        mockStatic.when(NanopubUtils::getHttpClient).thenReturn(mockHttpClient);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockStatic.close();
+        clearRegistryInfoCache();
+    }
+
+    /**
+     * ServerIterator keeps loaded registry infos in a static map, which would otherwise leak
+     * between tests that use the same registry URL with different flags.
+     */
+    private void clearRegistryInfoCache() throws Exception {
+        Field f = ServerIterator.class.getDeclaredField("serverInfos");
+        f.setAccessible(true);
+        ((Map<?, ?>) f.get(null)).clear();
+    }
+
+    private void stubRegistry(boolean isLocalInstance) throws Exception {
+        String json = "{\"status\":\"ready\",\"isLocalInstance\":" + isLocalInstance + "}";
+        CloseableHttpResponse getResponse = mock(CloseableHttpResponse.class);
+        HttpEntity getEntity = mock(HttpEntity.class);
+        when(getEntity.getContent()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+        when(getResponse.getEntity()).thenReturn(getEntity);
+        when(mockHttpClient.execute(any(HttpGet.class))).thenReturn(getResponse);
+
+        CloseableHttpResponse postResponse = mock(CloseableHttpResponse.class);
+        StatusLine statusLine = mock(StatusLine.class);
+        when(statusLine.getStatusCode()).thenReturn(201);
+        when(postResponse.getStatusLine()).thenReturn(statusLine);
+        when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(postResponse);
+    }
+
     private static Nanopub grlcQuery(String sparql) throws Exception {
         NanopubCreator creator = TestUtils.getNanopubCreator();
         creator.addAssertionStatement(anyIri, KPXL_GRLC.SPARQL, TestUtils.vf.createLiteral(sparql));
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(anyIri, anyIri);
+        return creator.finalizeTrustyNanopub();
+    }
+
+    private static Nanopub protectedNanopub() throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, anyIri, anyIri);
+        creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
+        creator.addPubinfoStatement(RDF.TYPE, NPX.PROTECTED_NANOPUB);
+        return creator.finalizeTrustyNanopub();
+    }
+
+    private static Nanopub plainNanopub() throws Exception {
+        NanopubCreator creator = TestUtils.getNanopubCreator();
+        creator.addAssertionStatement(anyIri, anyIri, anyIri);
         creator.addProvenanceStatement(creator.getAssertionUri(), anyIri, anyIri);
         creator.addPubinfoStatement(anyIri, anyIri);
         return creator.finalizeTrustyNanopub();
@@ -30,6 +109,42 @@ class PublishNanopubTest {
 
         assertTrue(ex.getMessage().contains("Can't publish nanopublication with invalid SPARQL"), ex.getMessage());
         assertTrue(ex.getMessage().contains("U+00A0 (NO-BREAK SPACE)"), ex.getMessage());
+    }
+
+    @Test
+    void protectedNanopubIsPublishedToLocalInstance() throws Exception {
+        stubRegistry(true);
+
+        String url = new PublishNanopub().publishNanopub(protectedNanopub(), LOCAL_REGISTRY_URL);
+
+        assertNotNull(url);
+        assertTrue(url.startsWith(LOCAL_REGISTRY_URL + "np/"));
+        verify(mockHttpClient).execute(any(HttpPost.class));
+    }
+
+    @Test
+    void protectedNanopubIsNotPublishedToPublicRegistry() throws Exception {
+        stubRegistry(false);
+        PublishNanopub publisher = new PublishNanopub();
+        Nanopub nanopub = protectedNanopub();
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> publisher.publishNanopub(nanopub, PUBLIC_REGISTRY_URL));
+
+        assertTrue(ex.getMessage().contains("Can't publish protected nanopublication"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("local instance"), ex.getMessage());
+        verify(mockHttpClient, never()).execute(any(HttpPost.class));
+    }
+
+    @Test
+    void unprotectedNanopubIsPublishedToPublicRegistry() throws Exception {
+        stubRegistry(false);
+
+        String url = new PublishNanopub().publishNanopub(plainNanopub(), PUBLIC_REGISTRY_URL);
+
+        assertNotNull(url);
+        assertTrue(url.startsWith(PUBLIC_REGISTRY_URL + "np/"));
+        verify(mockHttpClient).execute(any(HttpPost.class));
     }
 
 }

--- a/src/test/java/org/nanopub/extra/server/RegistryInfoTest.java
+++ b/src/test/java/org/nanopub/extra/server/RegistryInfoTest.java
@@ -35,31 +35,38 @@ class RegistryInfoTest {
     private static final int ACCOUNT_COUNT = 513;
     private static final int NANOPUB_COUNT = 63963;
     private static final int LOAD_COUNTER = 63963;
+    private static final String REGISTRY_VERSION = "1.12.1";
 
     private static final String registryInfoJsonString = String.format(
-            "{\"setupId\":%d,\"trustStateCounter\":%d,\"lastTrustStateUpdate\":\"%s\",\"trustStateHash\":\"%s\",\"status\":\"%s\",\"coverageTypes\":\"%s\",\"coverageAgents\":\"%s\",\"currentSetting\":\"%s\",\"originalSetting\":\"%s\",\"agentCount\":%d,\"accountCount\":%d,\"nanopubCount\":%d,\"loadCounter\":%d}",
-            SETUP_ID, TRUST_STATE_COUNTER, LAST_TRUST_STATE_UPDATE, TRUST_STATE_HASH, STATUS, COVERAGE_TYPES, COVERAGE_AGENTS, CURRENT_SETTING, ORIGINAL_SETTING, AGENT_COUNT, ACCOUNT_COUNT, NANOPUB_COUNT, LOAD_COUNTER
+            "{\"setupId\":%d,\"trustStateCounter\":%d,\"lastTrustStateUpdate\":\"%s\",\"trustStateHash\":\"%s\",\"status\":\"%s\",\"coverageTypes\":\"%s\",\"coverageAgents\":\"%s\",\"currentSetting\":\"%s\",\"originalSetting\":\"%s\",\"agentCount\":%d,\"accountCount\":%d,\"nanopubCount\":%d,\"loadCounter\":%d,\"registryVersion\":\"%s\",\"isLocalInstance\":true,\"isTestInstance\":false,\"optionalLoadEnabled\":true,\"trustCalculationEnabled\":false}",
+            SETUP_ID, TRUST_STATE_COUNTER, LAST_TRUST_STATE_UPDATE, TRUST_STATE_HASH, STATUS, COVERAGE_TYPES, COVERAGE_AGENTS, CURRENT_SETTING, ORIGINAL_SETTING, AGENT_COUNT, ACCOUNT_COUNT, NANOPUB_COUNT, LOAD_COUNTER, REGISTRY_VERSION
     );
+
+    // As reported by registries older than 1.12.0, which know none of the fields added for #144:
+    private static final String legacyRegistryInfoJsonString = String.format("{\"setupId\":%d,\"status\":\"%s\"}", SETUP_ID, STATUS);
 
     private final String validUrl = "https://registry.nanodash.net/";
     private final String invalidUrl = "https://invalid.registry.url/";
 
     MockedStatic<NanopubUtils> mockStatic = mockStatic(NanopubUtils.class);
+    private HttpEntity mockEntity;
     private RegistryInfo registryInfo;
 
     @BeforeEach
     void setUp() throws IOException, RegistryInfo.RegistryInfoException {
-        InputStream mockInputStream = new ByteArrayInputStream(registryInfoJsonString.getBytes(StandardCharsets.UTF_8));
-
         CloseableHttpClient mockHttpClient = mock(CloseableHttpClient.class);
         CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
-        HttpEntity mockEntity = mock(HttpEntity.class);
+        mockEntity = mock(HttpEntity.class);
         when(mockHttpClient.execute(any(HttpGet.class))).thenReturn(mockResponse);
         when(mockResponse.getEntity()).thenReturn(mockEntity);
-        when(mockEntity.getContent()).thenReturn(mockInputStream);
         mockStatic.when(NanopubUtils::getHttpClient).thenReturn(mockHttpClient);
 
-        registryInfo = RegistryInfo.load(validUrl);
+        registryInfo = loadRegistryInfo(registryInfoJsonString);
+    }
+
+    private RegistryInfo loadRegistryInfo(String json) throws IOException, RegistryInfo.RegistryInfoException {
+        when(mockEntity.getContent()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+        return RegistryInfo.load(validUrl);
     }
 
     @AfterEach
@@ -146,6 +153,30 @@ class RegistryInfoTest {
     @Test
     void getLoadCounter() {
         assertEquals(LOAD_COUNTER, registryInfo.getLoadCounter());
+    }
+
+    @Test
+    void getRegistryVersion() {
+        assertEquals(REGISTRY_VERSION, registryInfo.getRegistryVersion());
+    }
+
+    @Test
+    void getInstanceFlags() {
+        assertTrue(registryInfo.isLocalInstance());
+        assertFalse(registryInfo.isTestInstance());
+        assertTrue(registryInfo.isOptionalLoadEnabled());
+        assertFalse(registryInfo.isTrustCalculationEnabled());
+    }
+
+    @Test
+    void flagsDefaultToFalseForLegacyRegistries() throws Exception {
+        RegistryInfo legacy = loadRegistryInfo(legacyRegistryInfoJsonString);
+
+        assertNull(legacy.getRegistryVersion());
+        assertFalse(legacy.isLocalInstance());
+        assertFalse(legacy.isTestInstance());
+        assertFalse(legacy.isOptionalLoadEnabled());
+        assertFalse(legacy.isTrustCalculationEnabled());
     }
 
     @Test


### PR DESCRIPTION
Fixes #143 and its prerequisite #144.

## #144 — `RegistryInfo` dropped fields

`RegistryInfo` is deserialized straight into its declared fields, so anything the registry reports that isn't declared there was silently dropped. Added the five fields current registries actually send (verified against `registry.knowledgepixels.com`, which reports `registryVersion`, `isTestInstance`, `isLocalInstance`, `optionalLoadEnabled`, `trustCalculationEnabled`).

The accessors are null-tolerant: `getRegistryVersion()` returns `String`/null, the four flags return primitive `boolean`, so a registry older than 1.12.0 that omits them yields `false` — the safe default for every consumer.

`serialVersionUID` is pinned to the value `serialver` computed for the class *before* these fields were added. `ServerIterator` writes registry lists to `~/.nanopub/cachedservers` with Java serialization; without the pin, adding fields changes the computed UID and every user's cache is silently discarded on upgrade. Verified that a cache file written by the old class still deserializes with the new one (new fields null, `isLocalInstance()` false).

## #143 — protected nanopubs could not be published anywhere

`publishNanopub()` rejected any `npx:ProtectedNanopub` outright, before looking at the target registry, so there was no way to publish one at all — not even to a registry explicitly configured to accept them.

The check now sits inside the server loop and is evaluated per registry: a protected nanopub skips any registry that is not a local instance (no POST attempted) and moves on to the next candidate. It has to be in the loop body rather than before it, because `registryInfo` is a sticky field carried across `publishNanopub()` calls.

If no eligible registry remains, it fails with a message that says so, raised ahead of the dry-run branch so that `--dry-run` doesn't hide a misconfiguration behind `Nanopub NOT published: --dry-run`.

## Tests

Full suite passes (1215 tests).

- `RegistryInfoTest`: the new getters, plus a legacy-JSON case (all flags false, version null).
- New `PublishNanopubTest`: protected → local instance publishes; protected → public registry throws with no POST attempted; unprotected → public registry publishes as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFg2LXiXpsbcekdbSRgSRA