### PR TITLE
fix: let the registry instance-list override win over the cached list

### DIFF
--- a/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
@@ -71,6 +71,23 @@ public class NanopubServerUtils {
     }
 
     /**
+     * Returns the registry instance list configured via {@link #REGISTRY_INSTANCES_PROPERTY} or
+     * {@link #REGISTRY_INSTANCES_ENV}, or null when no override is configured.
+     * <p>
+     * Unlike {@link #getRegistryServerList()} this performs no bootstrap loading or service
+     * discovery and memoizes nothing, so it is safe to call merely to find out whether the caller
+     * is running against an explicitly configured set of registries.
+     *
+     * @return the overriding registry server URLs, or null if the override is unset or blank
+     */
+    public static List<String> getRegistryInstancesOverride() {
+        String override = System.getProperty(REGISTRY_INSTANCES_PROPERTY);
+        if (override == null || override.isEmpty()) override = System.getenv(REGISTRY_INSTANCES_ENV);
+        if (override == null || override.trim().isEmpty()) return null;
+        return List.of(override.trim().split("\\s+"));
+    }
+
+    /**
      * Returns the list of registry server URLs to seed a {@link ServerIterator}.
      * <p>
      * Sources, in order of priority:
@@ -88,13 +105,10 @@ public class NanopubServerUtils {
      */
     public static synchronized List<String> getRegistryServerList() {
         if (registryServerList != null) return registryServerList;
-        String override = System.getProperty(REGISTRY_INSTANCES_PROPERTY);
-        if (override == null || override.isEmpty()) override = System.getenv(REGISTRY_INSTANCES_ENV);
-        if (override != null && !override.trim().isEmpty()) {
-            List<String> list = new ArrayList<>();
-            for (String url : override.trim().split("\\s+")) list.add(url);
-            logger.info("Using {} registry instance(s) from override", list.size());
-            registryServerList = list;
+        List<String> override = getRegistryInstancesOverride();
+        if (override != null) {
+            logger.info("Using {} registry instance(s) from override", override.size());
+            registryServerList = override;
             return registryServerList;
         }
         List<String> bootstrap = getBootstrapServerList();

--- a/src/main/java/org/nanopub/extra/server/ServerIterator.java
+++ b/src/main/java/org/nanopub/extra/server/ServerIterator.java
@@ -36,12 +36,18 @@ public class ServerIterator implements Iterator<RegistryInfo> {
      * @param forceServerReload if true, forces a reload of the server list from the cache
      */
     public ServerIterator(boolean forceServerReload) {
-        if (!forceServerReload) {
+        // An explicitly configured instance list replaces bootstrap and discovery, so it has to
+        // replace the cache as well: a cache written by an earlier run against the public network
+        // would otherwise keep sending lookups there, silently, for up to 24 hours.
+        boolean hasOverride = NanopubServerUtils.getRegistryInstancesOverride() != null;
+        if (!forceServerReload && !hasOverride) {
             try {
                 loadCachedServers();
             } catch (Exception ex) {
                 logger.warn("Could not read the cached registry list from {}; falling back to the bootstrap list", getServerListFile(), ex);
             }
+        } else if (hasOverride) {
+            logger.debug("Ignoring the cached registry list: {} is set", NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
         }
         if (cachedServers == null) {
             serversToContact.addAll(NanopubServerUtils.getRegistryServerList());
@@ -169,6 +175,13 @@ public class ServerIterator implements Iterator<RegistryInfo> {
      * @throws java.io.IOException if an I/O error occurs
      */
     public static void writeCachedServers(List<RegistryInfo> cachedServers) throws IOException {
+        if (NanopubServerUtils.getRegistryInstancesOverride() != null) {
+            // The list was gathered under an instance-list override; persisting it would leak that
+            // private view into the shared cache file, which every JVM using this home directory
+            // reads, including ones running without the override.
+            logger.debug("Not caching the registry list: {} is set", NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+            return;
+        }
         if (cachedServers.size() < 5) return;
         File serverListFile = getServerListFile();
         serverListFile.getParentFile().mkdir();

--- a/src/test/java/org/nanopub/extra/server/NanopubServerUtilsTest.java
+++ b/src/test/java/org/nanopub/extra/server/NanopubServerUtilsTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class NanopubServerUtilsTest {
@@ -79,6 +80,23 @@ class NanopubServerUtilsTest {
         assertEquals(
                 List.of("https://reg-a.example/", "https://reg-b.example/"),
                 NanopubServerUtils.getRegistryServerList());
+    }
+
+    @Test
+    void getRegistryInstancesOverrideReturnsNullWhenUnsetOrBlank() {
+        assertNull(NanopubServerUtils.getRegistryInstancesOverride());
+
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, "   ");
+        assertNull(NanopubServerUtils.getRegistryInstancesOverride());
+    }
+
+    @Test
+    void getRegistryInstancesOverrideSplitsOnWhitespace() {
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY,
+                "  https://reg-a.example/ \t https://reg-b.example/\n");
+        assertEquals(
+                List.of("https://reg-a.example/", "https://reg-b.example/"),
+                NanopubServerUtils.getRegistryInstancesOverride());
     }
 
     @Test

--- a/src/test/java/org/nanopub/extra/server/ServerIteratorTest.java
+++ b/src/test/java/org/nanopub/extra/server/ServerIteratorTest.java
@@ -1,0 +1,141 @@
+package org.nanopub.extra.server;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ServerIteratorTest {
+
+    private static final String OVERRIDE_URL = "https://local-registry.example/";
+
+    @TempDir
+    Path tempHome;
+
+    private String oldUserHome;
+    private String oldOverride;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        oldUserHome = System.getProperty("user.home");
+        oldOverride = System.getProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+        System.setProperty("user.home", tempHome.toString());
+        System.clearProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+        resetCaches();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (oldUserHome == null) {
+            System.clearProperty("user.home");
+        } else {
+            System.setProperty("user.home", oldUserHome);
+        }
+        if (oldOverride == null) {
+            System.clearProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+        } else {
+            System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, oldOverride);
+        }
+        resetCaches();
+    }
+
+    private void resetCaches() throws Exception {
+        Field registryServerList = NanopubServerUtils.class.getDeclaredField("registryServerList");
+        registryServerList.setAccessible(true);
+        registryServerList.set(null, null);
+        Field serverInfos = ServerIterator.class.getDeclaredField("serverInfos");
+        serverInfos.setAccessible(true);
+        ((Map<?, ?>) serverInfos.get(null)).clear();
+    }
+
+    private File cacheFile() {
+        return tempHome.resolve(".nanopub/cachedservers").toFile();
+    }
+
+    private List<RegistryInfo> registries(String... urls) {
+        List<RegistryInfo> list = new ArrayList<>();
+        for (String url : urls) {
+            RegistryInfo info = new RegistryInfo();
+            info.url = url;
+            info.status = "ready";
+            list.add(info);
+        }
+        return list;
+    }
+
+    private List<RegistryInfo> publicRegistries() {
+        return registries("https://public-a.example/", "https://public-b.example/", "https://public-c.example/",
+                "https://public-d.example/", "https://public-e.example/");
+    }
+
+    private void writeCacheFile(List<RegistryInfo> registries) throws Exception {
+        File file = cacheFile();
+        file.getParentFile().mkdirs();
+        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(file))) {
+            oos.writeObject(registries);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> serversToContact(ServerIterator iterator) throws Exception {
+        Field f = ServerIterator.class.getDeclaredField("serversToContact");
+        f.setAccessible(true);
+        return (List<String>) f.get(iterator);
+    }
+
+    private Object cachedServers(ServerIterator iterator) throws Exception {
+        Field f = ServerIterator.class.getDeclaredField("cachedServers");
+        f.setAccessible(true);
+        return f.get(iterator);
+    }
+
+    @Test
+    void cachedListIsUsedWhenNoOverrideIsSet() throws Exception {
+        writeCacheFile(publicRegistries());
+
+        ServerIterator iterator = new ServerIterator();
+
+        assertNotNull(cachedServers(iterator), "A fresh cache file should be picked up");
+        assertTrue(serversToContact(iterator).isEmpty(), "The bootstrap list should not be consulted");
+        assertEquals("https://public-a.example/", iterator.next().getUrl());
+    }
+
+    @Test
+    void overrideBeatsTheCachedList() throws Exception {
+        writeCacheFile(publicRegistries());
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, OVERRIDE_URL);
+
+        ServerIterator iterator = new ServerIterator();
+
+        assertNull(cachedServers(iterator), "The cache must be ignored when an override is configured");
+        assertEquals(List.of(OVERRIDE_URL), serversToContact(iterator));
+    }
+
+    @Test
+    void writeCachedServersPersistsTheListWithoutAnOverride() throws Exception {
+        ServerIterator.writeCachedServers(publicRegistries());
+
+        assertTrue(cacheFile().exists());
+    }
+
+    @Test
+    void writeCachedServersRefusesToPersistUnderAnOverride() throws Exception {
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, OVERRIDE_URL);
+
+        ServerIterator.writeCachedServers(publicRegistries());
+
+        assertFalse(cacheFile().exists(), "A list gathered under an override must not poison the shared cache");
+    }
+
+}


### PR DESCRIPTION
Fixes #145.

## The problem

The no-argument `ServerIterator` prefers the serialized registry list cached in `~/.nanopub/cachedservers` and only falls back to `NanopubServerUtils.getRegistryServerList()` when that cache is missing, unreadable, or older than 24 h. The `nanopub.registry.instances` / `NANOPUB_REGISTRY_INSTANCES` override is resolved *inside* `getRegistryServerList()`, so it was reached only on the fallback path.

Consequence: a machine or container home with a fresh cache written by an earlier run against the public network ignores the override for up to 24 h. The `logger.info("Using {} registry instance(s) from override", …)` line lives on the same unreached path, so there is no trace of it in the log either. `GetNanopub.get(...)` keeps going to the public registries — which for a private deployment means failed lookups *and* artifact codes that only exist locally being disclosed to third parties.

## The fix

**Skip the cache when an override is configured.** This matches what `getRegistryServerList()`'s javadoc already promises — the override "Replaces both bootstrap and discovery when set" — so it should replace the cache too. Intersecting cache against override was the alternative, but it fails in exactly the motivating case: a private registry URL never appears in a cache built against the public network, so the intersection comes out empty and the client is left with no registries at all.

**Don't persist a list gathered under an override.** `writeCachedServers()` has one caller, `FetchIndex`, and its existing `size() < 5` guard happens to stop a single-URL private override today. A 5+ URL override would still leak that private view into the cache file, which is shared by every JVM using the same home directory, including ones running without the override.

**New accessor `NanopubServerUtils.getRegistryInstancesOverride()`.** The override check could not reuse `getRegistryServerList()`: that method memoizes into a static field and triggers bootstrap loading plus service discovery as a side effect, so calling it just to ask "is an override set?" would poison the memo and do network work. The new accessor parses the property/env var, memoizes nothing, and is now the single place the override is resolved — `getRegistryServerList()` delegates to it.

## Tests

Full suite passes (1250 tests, up from 1244).

New `ServerIteratorTest` (redirects `user.home` to a `@TempDir` and resets the memoized statics around each test):
- cached list is used when no override is set;
- override beats a fresh cache file — the cache is not even read;
- `writeCachedServers` persists normally without an override;
- `writeCachedServers` refuses to persist under one.

`NanopubServerUtilsTest` gained coverage for the new accessor: null when unset or blank, and whitespace splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFg2LXiXpsbcekdbSRgSRA