### PR TITLE
fix: name the actual override source in the registry cache log lines

### DIFF
--- a/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
+++ b/src/main/java/org/nanopub/extra/server/NanopubServerUtils.java
@@ -81,10 +81,39 @@ public class NanopubServerUtils {
      * @return the overriding registry server URLs, or null if the override is unset or blank
      */
     public static List<String> getRegistryInstancesOverride() {
+        InstancesOverride override = resolveRegistryInstancesOverride();
+        return override == null ? null : override.urls();
+    }
+
+    /**
+     * Returns the name of the configuration source that supplied the instance-list override
+     * ({@link #REGISTRY_INSTANCES_PROPERTY} or {@link #REGISTRY_INSTANCES_ENV}), or null when no
+     * override is configured. Intended for log messages, where naming the source the operator
+     * actually set is more useful than naming the one that happens to be checked first.
+     *
+     * @return the name of the property or environment variable in effect, or null if unset
+     */
+    static String getRegistryInstancesOverrideSource() {
+        InstancesOverride override = resolveRegistryInstancesOverride();
+        return override == null ? null : override.source();
+    }
+
+    private record InstancesOverride(String source, List<String> urls) {
+    }
+
+    /**
+     * Single resolution point for the instance-list override, so that the URLs and the name of the
+     * source they came from cannot drift apart.
+     */
+    private static InstancesOverride resolveRegistryInstancesOverride() {
+        String source = REGISTRY_INSTANCES_PROPERTY;
         String override = System.getProperty(REGISTRY_INSTANCES_PROPERTY);
-        if (override == null || override.isEmpty()) override = System.getenv(REGISTRY_INSTANCES_ENV);
+        if (override == null || override.isEmpty()) {
+            source = REGISTRY_INSTANCES_ENV;
+            override = System.getenv(REGISTRY_INSTANCES_ENV);
+        }
         if (override == null || override.trim().isEmpty()) return null;
-        return List.of(override.trim().split("\\s+"));
+        return new InstancesOverride(source, List.of(override.trim().split("\\s+")));
     }
 
     /**

--- a/src/main/java/org/nanopub/extra/server/ServerIterator.java
+++ b/src/main/java/org/nanopub/extra/server/ServerIterator.java
@@ -39,15 +39,17 @@ public class ServerIterator implements Iterator<RegistryInfo> {
         // An explicitly configured instance list replaces bootstrap and discovery, so it has to
         // replace the cache as well: a cache written by an earlier run against the public network
         // would otherwise keep sending lookups there, silently, for up to 24 hours.
-        boolean hasOverride = NanopubServerUtils.getRegistryInstancesOverride() != null;
-        if (!forceServerReload && !hasOverride) {
-            try {
-                loadCachedServers();
-            } catch (Exception ex) {
-                logger.warn("Could not read the cached registry list from {}; falling back to the bootstrap list", getServerListFile(), ex);
+        if (!forceServerReload) {
+            String overrideSource = NanopubServerUtils.getRegistryInstancesOverrideSource();
+            if (overrideSource != null) {
+                logger.debug("Ignoring the cached registry list: {} is set", overrideSource);
+            } else {
+                try {
+                    loadCachedServers();
+                } catch (Exception ex) {
+                    logger.warn("Could not read the cached registry list from {}; falling back to the bootstrap list", getServerListFile(), ex);
+                }
             }
-        } else if (hasOverride) {
-            logger.debug("Ignoring the cached registry list: {} is set", NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
         }
         if (cachedServers == null) {
             serversToContact.addAll(NanopubServerUtils.getRegistryServerList());
@@ -175,11 +177,12 @@ public class ServerIterator implements Iterator<RegistryInfo> {
      * @throws java.io.IOException if an I/O error occurs
      */
     public static void writeCachedServers(List<RegistryInfo> cachedServers) throws IOException {
-        if (NanopubServerUtils.getRegistryInstancesOverride() != null) {
+        String overrideSource = NanopubServerUtils.getRegistryInstancesOverrideSource();
+        if (overrideSource != null) {
             // The list was gathered under an instance-list override; persisting it would leak that
             // private view into the shared cache file, which every JVM using this home directory
             // reads, including ones running without the override.
-            logger.debug("Not caching the registry list: {} is set", NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY);
+            logger.debug("Not caching the registry list: {} is set", overrideSource);
             return;
         }
         if (cachedServers.size() < 5) return;

--- a/src/test/java/org/nanopub/extra/server/NanopubServerUtilsTest.java
+++ b/src/test/java/org/nanopub/extra/server/NanopubServerUtilsTest.java
@@ -100,6 +100,20 @@ class NanopubServerUtilsTest {
     }
 
     @Test
+    void getRegistryInstancesOverrideSourceNamesTheConfiguredSource() {
+        assertNull(NanopubServerUtils.getRegistryInstancesOverrideSource());
+
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, "https://reg-a.example/");
+        assertEquals(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY,
+                NanopubServerUtils.getRegistryInstancesOverrideSource());
+
+        // A blank value is not an override, so neither accessor reports one.
+        System.setProperty(NanopubServerUtils.REGISTRY_INSTANCES_PROPERTY, "   ");
+        assertNull(NanopubServerUtils.getRegistryInstancesOverrideSource());
+        assertNull(NanopubServerUtils.getRegistryInstancesOverride());
+    }
+
+    @Test
     void getRegistryServerListUnionsBootstrapAndDiscovered() throws Exception {
         List<String> bootstrap = NanopubServerUtils.getBootstrapServerList();
         // Pick one real bootstrap URL to verify dedupe, plus a fresh URL to verify appending.

--- a/src/test/java/org/nanopub/extra/server/ServerIteratorTest.java
+++ b/src/test/java/org/nanopub/extra/server/ServerIteratorTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.nanopub.extra.services.ServiceLookup;
+import org.nanopub.vocabulary.NPS;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -57,6 +59,18 @@ class ServerIteratorTest {
         Field serverInfos = ServerIterator.class.getDeclaredField("serverInfos");
         serverInfos.setAccessible(true);
         ((Map<?, ?>) serverInfos.get(null)).clear();
+        ServiceLookup.clearCache();
+    }
+
+    /**
+     * Pre-populates the discovery cache so that the no-override fallback path resolves its server
+     * list without contacting the network.
+     */
+    @SuppressWarnings("unchecked")
+    private void seedServiceLookupCache(List<String> urls) throws Exception {
+        Field f = ServiceLookup.class.getDeclaredField("cache");
+        f.setAccessible(true);
+        ((Map<org.eclipse.rdf4j.model.IRI, List<String>>) f.get(null)).put(NPS.NANOPUB_REGISTRY_1_0, urls);
     }
 
     private File cacheFile() {
@@ -120,6 +134,17 @@ class ServerIteratorTest {
 
         assertNull(cachedServers(iterator), "The cache must be ignored when an override is configured");
         assertEquals(List.of(OVERRIDE_URL), serversToContact(iterator));
+    }
+
+    @Test
+    void forcedReloadSkipsTheCacheWithoutAnOverride() throws Exception {
+        writeCacheFile(publicRegistries());
+        seedServiceLookupCache(List.of("https://discovered.example/"));
+
+        ServerIterator iterator = new ServerIterator(true);
+
+        assertNull(cachedServers(iterator), "forceServerReload must bypass the cache on its own");
+        assertTrue(serversToContact(iterator).contains("https://discovered.example/"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #147, addressing two review nits on the merged code. Both are logging-accuracy fixes; no behaviour change.

## 1. The log lines named the wrong source

`ServerIterator.java:50` and `:178` both logged `"… {} is set"` with `REGISTRY_INSTANCES_PROPERTY`, so they always said `nanopub.registry.instances` even when the override had actually come from `NANOPUB_REGISTRY_INSTANCES`. That is misleading precisely where the env var is the normal way to configure this — in a container.

Rather than duplicating the property-then-env resolution to answer "which one was it?", the URLs and the source name are now resolved together in one private method behind two accessors (`getRegistryInstancesOverride()` for the URLs, package-private `getRegistryInstancesOverrideSource()` for the name), so the two answers cannot drift apart.

## 2. The override branch fired under `forceServerReload`

`else if (hasOverride)` was also reached when `forceServerReload` was true, reporting the override as the reason the cache was skipped when the caller had already asked for it to be skipped. The override check is now nested inside the `!forceServerReload` branch, so it only reports when it is the actual reason. The cache was, and still is, skipped in both cases.

## Tests

Full suite passes (1252, up from 1250).

- `ServerIteratorTest.forcedReloadSkipsTheCacheWithoutAnOverride` — a guard for the restructure: `new ServerIterator(true)` bypasses a fresh cache file on its own, with no override set. It seeds the `ServiceLookup` cache so the fallback path resolves without network discovery.
- `NanopubServerUtilsTest.getRegistryInstancesOverrideSourceNamesTheConfiguredSource` — null when unset, the property name when set, and null for a blank value from both accessors.

The env-var branch is not directly testable (`System.getenv` is immutable in-process); it is covered by construction, sharing the single resolution path with the property branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VFg2LXiXpsbcekdbSRgSRA